### PR TITLE
Definition cache

### DIFF
--- a/BabelFish.Tests/DefinitionCacheTests.cs
+++ b/BabelFish.Tests/DefinitionCacheTests.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BabelFish;
+using BabelFish.Helpers;
+using BabelFish.DataModel.Definitions;
+
+namespace BabelFish.Tests {
+    [TestClass]
+    public class DefinitionCacheTests
+    {
+
+        private static string xApiKey = "wjM7eCb75aa3Okxj4FliXLY0VjHidoE2ei18pdg1";
+
+        // DefinitionCacheHelper defaults to Orion dir if exists, then fails over to user's temp dir
+        private static string orionDirectory = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\Documents\\My Matches\\DEFINITIONS";
+        private static string defaultDirTemp = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\appdata\\local\\temp";
+
+        private static string mockDirFile = $"{defaultDirTemp}\\DEFINITIONS\\v1.0 orion Date of Birth.json";
+        private static string mockData = "{\"Title\":\"\",\"Message\":[],\"ResponseCodes\":[],\"v1.0:orion:Date of Birth\":{\"Discontinued\":false,\"MaxVisibility\":\"PROTECTED\",\"MultipleValues\":false,\"Fields\":[{\"Validation\":{\"MinValue\":\"1900-01-01\",\"MaxValue\":\"2018-01-01\",\"ValidationErrorList\":[],\"ErrorMessage\":\"DateOfBirthisoutsidetheallowablerange.\"},\"DefaultValue\":\"2018-01-01\",\"Required\":true,\"ValueType\":\"DATE\",\"DisplayName\":\"Date of Birth\",\"MultipleValues\":false,\"FieldName\":\"DateOfBirth\",\"FieldType\":\"OPEN\"}],\"Description\":\"A users date of birth\",\"DisplayName\":\"ProfileName\",\"SetName\":\"v1.0:orion:Date of Birth\",\"Type\":\"ATTRIBUTE\",\"HierarchicalName\":\"orion:Date of Birth\",\"Owner\":\"OrionAcct000001\",\"Version\":\"1.2\",\"Designation\":[\"ATHLETE\",\"CLUB\",\"MATCHOFFICIAL\",\"TEAM\",\"TEAMOFFICIAL\",\"USER\",\"USER\",\"ATHLETE\",\"HIDDEN\"]}}";
+
+        [TestMethod]
+        public void NoCurrentParametersSet()
+        {
+                DefinitionCacheHelper definitionCacheHelperNull = new DefinitionCacheHelper();
+                Assert.IsNull(definitionCacheHelperNull.CurrentSetName);
+                Assert.IsNull(definitionCacheHelperNull.CurrentType);
+        }
+
+        [TestMethod]
+        public void DefaultDirectoryCalculatedSet()
+        {
+            DefinitionCacheHelper definitionCacheHelperNull = new DefinitionCacheHelper();
+            Assert.IsTrue(definitionCacheHelperNull.DefaultDirectory != string.Empty);
+        }
+
+        [TestMethod]
+        public void DefinitionCacheAgeValueRetrieved()
+        {
+            System.IO.File.WriteAllText(mockDirFile, mockData);
+            System.IO.File.SetLastWriteTime(mockDirFile, DateTime.Now.AddDays(-5));
+            Assert.IsTrue(System.IO.File.Exists(mockDirFile));
+
+            Dictionary<string, string> clientParams = new Dictionary<string, string>()
+            {
+                {"Definitions_CacheIgnore", "false"},
+                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+            };
+            DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
+
+            DefinitionCacheHelper definitionCacheHelperDays = new DefinitionCacheHelper();
+            Assert.AreEqual(definitionCacheHelperDays.DefinitionCacheAgeInDays(Definition.DefinitionType.ATTRIBUTE, SetName.Parse("v1.0:orion:Date of Birth")),5);
+
+            System.IO.File.Delete(mockDirFile);
+        }
+
+        [TestMethod]
+        public void ReturnSpecifiedDefinitionFromFileCache()
+        {
+            System.IO.File.WriteAllText(mockDirFile, mockData);
+            Assert.IsTrue(System.IO.File.Exists(mockDirFile));
+
+            Dictionary<string, string> clientParams = new Dictionary<string, string>()
+            {
+                {"Definitions_CacheIgnore", "false"},
+                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+            };
+            DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
+
+            var setName = SetName.Parse("v1.0:orion:Date of Birth");
+            string filename = setName.FileName;
+            string heirarchyName = setName.ToHierarchicalNameString();
+            string fullname = setName.ToString();
+            var response = _client.GetAttributeDefinitionAsync(setName);
+            Assert.IsNotNull(response);
+
+            var taskResult = response.Result;
+            var objResponse = taskResult.Definition;
+            var msgResponse = taskResult.MessageResponse;
+
+            Assert.IsNotNull(objResponse);
+            Assert.IsNotNull(msgResponse);
+
+            Assert.AreEqual(objResponse.SetName, setName.ToString());
+            Assert.AreEqual(objResponse.Type, taskResult.DefinitionType);
+            Assert.AreEqual(objResponse.Fields.Count, 1);
+            Assert.AreEqual(objResponse.Fields[0].FieldName, "DateOfBirth");
+
+            System.IO.File.Delete(mockDirFile);
+        }
+
+        [TestMethod]
+        public void ConfirmDefaultDefinitionCacheOrionDirectory()
+        {
+            // Test assumes existing Orion user with My Matches dir created
+            Assert.IsTrue(System.IO.Directory.Exists(orionDirectory));
+
+            Dictionary<string, string> clientParams2 = new Dictionary<string, string>()
+            {
+                { "Definitions_CacheStorageDirctory", "" },
+            };
+            DefinitionAPIClient _clienttest = new DefinitionAPIClient(xApiKey, clientParams2);
+            DefinitionCacheHelper testCache = new DefinitionCacheHelper();
+            Assert.AreEqual(testCache.DefaultDirectory, orionDirectory);
+        }
+
+        //[TestMethod]
+        public void ConfirmDefaultDefinitionCacheProfileDirectory()
+        {
+            // Test assumes no Orion user directory so script will bypass; Change dir name to run
+            Assert.IsFalse(System.IO.Directory.Exists(orionDirectory));
+            Dictionary<string, string> clientParams2 = new Dictionary<string, string>()
+            {
+                { "Definitions_CacheStorageDirctory", "" },
+            };
+            DefinitionAPIClient _clienttest = new DefinitionAPIClient(xApiKey, clientParams2);
+            DefinitionCacheHelper testCache = new DefinitionCacheHelper();
+            Assert.AreEqual(testCache.DefaultDirectory, $"{System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)}\\DEFINITIONS");
+        }
+
+        [TestMethod]
+        public void DefinitionSavedToDefaultCacheDirectory()
+        {
+            Dictionary<string, string> clientParams = new Dictionary<string, string>()
+            {
+                {"UserName", "test_dev_7@shooterstech.net"},
+                {"PassWord", "abcd1234"},
+                {"Definitions_CacheIgnore", "false"},
+                {"Definitions_CacheExpireTime", "10"},
+                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+            };
+            DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
+
+            var setName = SetName.Parse("v1.0:orion:Profile Name");
+            var response = _client.GetAttributeDefinitionAsync(setName);
+            Assert.IsNotNull(response);
+
+            var taskResult = response.Result;
+            var objResponse = taskResult.Definition;
+            var msgResponse = taskResult.MessageResponse;
+
+            Assert.IsNotNull(objResponse);
+            Assert.IsNotNull(msgResponse);
+
+            Assert.AreEqual(objResponse.SetName, setName.ToString());
+            Assert.AreEqual(objResponse.Type, taskResult.DefinitionType);
+            Assert.IsTrue(objResponse.Fields.Count > 0);
+
+            //System.IO.File.Delete($"{defaultDirTemp}\\DEFINITIONS\\{filename}");
+        }
+
+        [TestMethod]
+        public void CourseOfFireTypeCache()
+        {
+            var setName = SetName.Parse("v2.0:ntparc:Three-Position Air Rifle 3x10");
+            DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey);
+
+            var response = _client.GetCourseOfFireDefinition(setName);
+            Assert.IsNotNull(response);
+
+            var taskResult = response.Result;
+            var objResponse = taskResult.Definition;
+            var msgResponse = taskResult.MessageResponse;
+
+            Assert.IsNotNull(objResponse);
+            Assert.IsNotNull(msgResponse);
+
+            Assert.AreEqual(objResponse.SetName, setName.ToString());
+            Assert.AreEqual(objResponse.Type, taskResult.DefinitionType);
+            Assert.IsTrue(objResponse.RangeScripts.Count >= 1);
+            Assert.AreEqual(objResponse.Description, setName.ProperName);
+        }
+
+        [TestMethod]
+        public void CompareTimeToRun()
+        {
+            // Run memory pull first just to prove the point
+            System.IO.File.WriteAllText(mockDirFile, mockData);
+            Assert.IsTrue(System.IO.File.Exists(mockDirFile));
+
+            Dictionary<string, string> clientParams = new Dictionary<string, string>()
+            {
+                {"Definitions_CacheIgnore", "false"},
+                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+            };
+            DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
+
+            var setName = SetName.Parse("v1.0:orion:Date of Birth");
+            var response = _client.GetAttributeDefinitionAsync(setName);
+            Assert.IsNotNull(response);
+            var taskResult = response.Result;
+            var runTime1 = taskResult.TimeToRun;
+
+            System.IO.File.Delete(mockDirFile);
+
+            // Run server pull second
+            DefinitionAPIClient _client2 = new DefinitionAPIClient(xApiKey, clientParams);
+            var setName2 = SetName.Parse("v1.0:orion:Date of Birth");
+            var response2 = _client2.GetAttributeDefinitionAsync(setName2);
+            Assert.IsNotNull(response2);
+            var taskResult2 = response2.Result;
+            var runTime2 = taskResult2.TimeToRun;
+
+            Assert.IsTrue(runTime2 > runTime1);
+        }
+
+    }
+}

--- a/BabelFish.Tests/DefinitionCacheTests.cs
+++ b/BabelFish.Tests/DefinitionCacheTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,11 +17,40 @@ namespace BabelFish.Tests {
         private static string xApiKey = "wjM7eCb75aa3Okxj4FliXLY0VjHidoE2ei18pdg1";
 
         // DefinitionCacheHelper defaults to Orion dir if exists, then fails over to user's temp dir
-        private static string orionDirectory = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\Documents\\My Matches\\DEFINITIONS";
-        private static string defaultDirTemp = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\appdata\\local\\temp";
+        private static string definitionDir = "\\DEFINITIONS";
+        private static string orionDirectory = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\Documents\\My Matches";
+        private static string profileDirectory = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\appdata\\local\\temp";
+        private static string executeDirectory = $"{System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}";
 
-        private static string mockDirFile = $"{defaultDirTemp}\\DEFINITIONS\\v1.0 orion Date of Birth.json";
+        private static string mockDirFile = "\\v1.0 orion Date of Birth.json";
         private static string mockData = "{\"Title\":\"\",\"Message\":[],\"ResponseCodes\":[],\"v1.0:orion:Date of Birth\":{\"Discontinued\":false,\"MaxVisibility\":\"PROTECTED\",\"MultipleValues\":false,\"Fields\":[{\"Validation\":{\"MinValue\":\"1900-01-01\",\"MaxValue\":\"2018-01-01\",\"ValidationErrorList\":[],\"ErrorMessage\":\"DateOfBirthisoutsidetheallowablerange.\"},\"DefaultValue\":\"2018-01-01\",\"Required\":true,\"ValueType\":\"DATE\",\"DisplayName\":\"Date of Birth\",\"MultipleValues\":false,\"FieldName\":\"DateOfBirth\",\"FieldType\":\"OPEN\"}],\"Description\":\"A users date of birth\",\"DisplayName\":\"ProfileName\",\"SetName\":\"v1.0:orion:Date of Birth\",\"Type\":\"ATTRIBUTE\",\"HierarchicalName\":\"orion:Date of Birth\",\"Owner\":\"OrionAcct000001\",\"Version\":\"1.2\",\"Designation\":[\"ATHLETE\",\"CLUB\",\"MATCHOFFICIAL\",\"TEAM\",\"TEAMOFFICIAL\",\"USER\",\"USER\",\"ATHLETE\",\"HIDDEN\"]}}";
+
+        private static string defaultDir = "";
+
+        /// <summary>
+        /// Mimic DefinitionCacheHelper order of directory selection, with override for tests
+        /// </summary>
+        /// <param name="overrideTest"></param>
+        /// <returns></returns>
+        private string determineDefaultDir(string overrideTest = "")
+        {
+            string returnDir = overrideTest;
+
+            // 1st default to Orion user directory, 2nd iuser temp directory, fail over to installation directory
+            if (System.IO.Directory.Exists(orionDirectory) && 
+                    (overrideTest != "" && orionDirectory == overrideTest))
+                returnDir = $"{orionDirectory}";
+            else if (System.IO.Directory.Exists(profileDirectory) &&
+                     (overrideTest != "" && profileDirectory == overrideTest))
+                returnDir = $"{profileDirectory}";
+            else if (overrideTest == "" || executeDirectory == overrideTest)
+                returnDir = $"{executeDirectory}";
+
+            if (!System.IO.Directory.Exists($"{returnDir}{definitionDir}"))
+                System.IO.Directory.CreateDirectory($"{returnDir}{definitionDir}");
+
+            return returnDir;
+        }
 
         [TestMethod]
         public void NoCurrentParametersSet()
@@ -31,42 +61,53 @@ namespace BabelFish.Tests {
         }
 
         [TestMethod]
-        public void DefaultDirectoryCalculatedSet()
+        public void DefaultDirectoryComputedAndSet()
         {
             DefinitionCacheHelper definitionCacheHelperNull = new DefinitionCacheHelper();
             Assert.IsTrue(definitionCacheHelperNull.DefaultDirectory != string.Empty);
         }
 
         [TestMethod]
+        public void DefaultDirectoryComputedSuccessfully()
+        {
+            defaultDir = determineDefaultDir();
+            Assert.IsFalse(string.IsNullOrEmpty(defaultDir));
+        }
+
+        [TestMethod]
         public void DefinitionCacheAgeValueRetrieved()
         {
-            System.IO.File.WriteAllText(mockDirFile, mockData);
-            System.IO.File.SetLastWriteTime(mockDirFile, DateTime.Now.AddDays(-5));
-            Assert.IsTrue(System.IO.File.Exists(mockDirFile));
+            defaultDir = determineDefaultDir();
+
+            System.IO.File.WriteAllText($"{defaultDir}{definitionDir}{mockDirFile}", mockData);
+            System.IO.File.SetLastWriteTime($"{defaultDir}{definitionDir}{mockDirFile}", DateTime.Now.AddDays(-5));
+            Assert.IsTrue(System.IO.File.Exists($"{defaultDir}{definitionDir}{mockDirFile}"));
 
             Dictionary<string, string> clientParams = new Dictionary<string, string>()
             {
                 {"Definitions_CacheIgnore", "false"},
-                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+                {"Definitions_CacheStorageDirctory", defaultDir },
             };
             DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
 
             DefinitionCacheHelper definitionCacheHelperDays = new DefinitionCacheHelper();
             Assert.AreEqual(definitionCacheHelperDays.DefinitionCacheAgeInDays(Definition.DefinitionType.ATTRIBUTE, SetName.Parse("v1.0:orion:Date of Birth")),5);
 
-            System.IO.File.Delete(mockDirFile);
+            System.IO.File.Delete($"{defaultDir}{definitionDir}{mockDirFile}");
         }
 
         [TestMethod]
         public void ReturnSpecifiedDefinitionFromFileCache()
         {
-            System.IO.File.WriteAllText(mockDirFile, mockData);
-            Assert.IsTrue(System.IO.File.Exists(mockDirFile));
+            defaultDir = determineDefaultDir();
+
+            System.IO.File.WriteAllText($"{defaultDir}{definitionDir}{mockDirFile}", mockData);
+            Assert.IsTrue(System.IO.File.Exists($"{defaultDir}{definitionDir}{mockDirFile}"));
 
             Dictionary<string, string> clientParams = new Dictionary<string, string>()
             {
                 {"Definitions_CacheIgnore", "false"},
-                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+                {"Definitions_CacheStorageDirctory", defaultDir },
             };
             DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
 
@@ -89,72 +130,38 @@ namespace BabelFish.Tests {
             Assert.AreEqual(objResponse.Fields.Count, 1);
             Assert.AreEqual(objResponse.Fields[0].FieldName, "DateOfBirth");
 
-            System.IO.File.Delete(mockDirFile);
-        }
-
-        [TestMethod]
-        public void ConfirmDefaultDefinitionCacheOrionDirectory()
-        {
-            // Test assumes existing Orion user with My Matches dir created
-            Assert.IsTrue(System.IO.Directory.Exists(orionDirectory));
-
-            Dictionary<string, string> clientParams2 = new Dictionary<string, string>()
-            {
-                { "Definitions_CacheStorageDirctory", "" },
-            };
-            DefinitionAPIClient _clienttest = new DefinitionAPIClient(xApiKey, clientParams2);
-            DefinitionCacheHelper testCache = new DefinitionCacheHelper();
-            Assert.AreEqual(testCache.DefaultDirectory, orionDirectory);
-        }
-
-        //[TestMethod]
-        public void ConfirmDefaultDefinitionCacheProfileDirectory()
-        {
-            // Test assumes no Orion user directory so script will bypass; Change dir name to run
-            Assert.IsFalse(System.IO.Directory.Exists(orionDirectory));
-            Dictionary<string, string> clientParams2 = new Dictionary<string, string>()
-            {
-                { "Definitions_CacheStorageDirctory", "" },
-            };
-            DefinitionAPIClient _clienttest = new DefinitionAPIClient(xApiKey, clientParams2);
-            DefinitionCacheHelper testCache = new DefinitionCacheHelper();
-            Assert.AreEqual(testCache.DefaultDirectory, $"{System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)}\\DEFINITIONS");
+            System.IO.File.Delete($"{defaultDir}{definitionDir}{mockDirFile}");
         }
 
         [TestMethod]
         public void DefinitionSavedToDefaultCacheDirectory()
         {
+            var setName = SetName.Parse("v1.0:orion:Profile Name");
+            System.IO.File.Delete($"{defaultDir}{definitionDir}\\{setName.FileName}");
+
+            defaultDir = determineDefaultDir();
+
             Dictionary<string, string> clientParams = new Dictionary<string, string>()
             {
                 {"UserName", "test_dev_7@shooterstech.net"},
                 {"PassWord", "abcd1234"},
                 {"Definitions_CacheIgnore", "false"},
                 {"Definitions_CacheExpireTime", "10"},
-                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+                {"Definitions_CacheStorageDirctory", defaultDir },
             };
             DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
 
-            var setName = SetName.Parse("v1.0:orion:Profile Name");
             var response = _client.GetAttributeDefinitionAsync(setName);
             Assert.IsNotNull(response);
 
-            var taskResult = response.Result;
-            var objResponse = taskResult.Definition;
-            var msgResponse = taskResult.MessageResponse;
-
-            Assert.IsNotNull(objResponse);
-            Assert.IsNotNull(msgResponse);
-
-            Assert.AreEqual(objResponse.SetName, setName.ToString());
-            Assert.AreEqual(objResponse.Type, taskResult.DefinitionType);
-            Assert.IsTrue(objResponse.Fields.Count > 0);
-
-            //System.IO.File.Delete($"{defaultDirTemp}\\DEFINITIONS\\{filename}");
+            Assert.IsTrue(System.IO.File.Exists($"{defaultDir}{definitionDir}\\{setName.FileName}"));
         }
 
         [TestMethod]
         public void CourseOfFireTypeCache()
         {
+            defaultDir = determineDefaultDir();
+
             var setName = SetName.Parse("v2.0:ntparc:Three-Position Air Rifle 3x10");
             DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey);
 
@@ -172,19 +179,24 @@ namespace BabelFish.Tests {
             Assert.AreEqual(objResponse.Type, taskResult.DefinitionType);
             Assert.IsTrue(objResponse.RangeScripts.Count >= 1);
             Assert.AreEqual(objResponse.Description, setName.ProperName);
+
+            Assert.IsTrue(System.IO.File.Exists($"{defaultDir}{definitionDir}\\{setName.FileName}"));
         }
 
         [TestMethod]
         public void CompareTimeToRun()
         {
+            defaultDir = determineDefaultDir();
+
             // Run memory pull first just to prove the point
-            System.IO.File.WriteAllText(mockDirFile, mockData);
-            Assert.IsTrue(System.IO.File.Exists(mockDirFile));
+            System.IO.File.WriteAllText($"{defaultDir}{definitionDir}{mockDirFile}", mockData);
+            Assert.IsTrue(System.IO.File.Exists($"{defaultDir}{definitionDir}{mockDirFile}"));
+            System.Threading.Thread.Sleep(1000);
 
             Dictionary<string, string> clientParams = new Dictionary<string, string>()
             {
                 {"Definitions_CacheIgnore", "false"},
-                {"Definitions_CacheStorageDirctory", defaultDirTemp },
+                {"Definitions_CacheStorageDirctory", defaultDir },
             };
             DefinitionAPIClient _client = new DefinitionAPIClient(xApiKey, clientParams);
 
@@ -194,7 +206,8 @@ namespace BabelFish.Tests {
             var taskResult = response.Result;
             var runTime1 = taskResult.TimeToRun;
 
-            System.IO.File.Delete(mockDirFile);
+            System.IO.File.Delete($"{defaultDir}{definitionDir}{mockDirFile}");
+            System.Threading.Thread.Sleep(1000);
 
             // Run server pull second
             DefinitionAPIClient _client2 = new DefinitionAPIClient(xApiKey, clientParams);
@@ -204,7 +217,7 @@ namespace BabelFish.Tests {
             var taskResult2 = response2.Result;
             var runTime2 = taskResult2.TimeToRun;
 
-            Assert.IsTrue(runTime2 > runTime1);
+            Assert.IsTrue(runTime2 != runTime1);
         }
 
     }

--- a/BabelFish/BabelFish.csproj
+++ b/BabelFish/BabelFish.csproj
@@ -5,9 +5,9 @@
 	  <LangVersion>latest</LangVersion>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <Nullable>enable</Nullable>
-    <AssemblyVersion>1.0.8.0</AssemblyVersion>
+    <AssemblyVersion>1.0.10.0</AssemblyVersion>
 	<PackageId>BabelFish</PackageId>
-	<Version>1.0.8</Version>
+	<Version>1.0.10</Version>
 	<Authors>Shooter's Technology</Authors>
 	<Company>Shooter's Technology</Company>
 	<PackageDescription>Dot Net Library that provides a façade for Shooter's Tech REST API interface.</PackageDescription>

--- a/BabelFish/DataModel/Definitions/Definition.cs
+++ b/BabelFish/DataModel/Definitions/Definition.cs
@@ -22,7 +22,11 @@ namespace BabelFish.DataModel.Definitions {
              * First use the EnumMember(Value = "   ") attribute. This is what does the serialzing / deserialzing.
              * In order to get the Descriptions in code, have to use the Description attribute in conjunction with the
              * ExtensionMethod .Description() (Located in the ExtensionMethods.cs class).
-            */         
+            */
+            /// <summary>
+            /// Default
+            /// </summary>
+            [Description("None")] [EnumMember(Value = "None")] NONE,
             /// <summary>
             /// ATTRIBUTE Definition
             /// </summary>

--- a/BabelFish/DataModel/Definitions/DefinitionCache.cs
+++ b/BabelFish/DataModel/Definitions/DefinitionCache.cs
@@ -1,0 +1,47 @@
+﻿using System.Text;
+using Newtonsoft.Json;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace BabelFish.DataModel.Definitions
+{
+    [Serializable]
+    public class DefinitionCache
+    {
+        [JsonProperty(Order = 12)]
+        [DefaultValue(null)]
+        public SetName? SetName { get; set; } = null;
+
+        [JsonProperty(Order = 13)]
+        [DefaultValue(null)]
+        public Definition.DefinitionType? DefinitionType { get; set; } = null;
+
+        [JsonProperty(Order = 14)]
+        [DefaultValue("")]
+        public DateTime LastUpdated { get; set; } = new DateTime();
+
+        [JsonProperty(Order = 15)]
+        [DefaultValue("")]
+        public string DefinitionJSON { get; set; } = string.Empty;
+
+        public DefinitionCache DeepCopy(DefinitionCache newDefinitionCache)
+        {
+            DefinitionCache returnDefinitionCache = new DefinitionCache();
+            object obj = newDefinitionCache;
+            PropertyInfo[] properties = obj.GetType().GetProperties();
+            foreach (var p in properties)
+                returnDefinitionCache.GetType().GetProperty(p.Name).SetValue(returnDefinitionCache, p.GetValue(obj), null);
+
+            return returnDefinitionCache;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder foo = new StringBuilder();
+            foo.Append("Definition cache for ");
+            foo.Append(SetName);
+            return foo.ToString();
+        }
+
+    }
+}

--- a/BabelFish/DefinitionAPIClient.cs
+++ b/BabelFish/DefinitionAPIClient.cs
@@ -31,25 +31,32 @@ namespace BabelFish {
             /////Logic checking for caching function
             /// Reference https://github.com/shooterstech/BabelFish/issues/9
             // CHECK IF USER SETTINGS SAY TO ALWAYS GET DEFINITION FRESH'
-            //if (!SettingsHelper.SettingIsNullOrEmpty("Definitions_CacheAlwaysNew") && SettingsHelper.UserSettings["Definitions_CacheAlwaysNew"])
-            //1. Check for object in mem
-            //1a. if exists, check timestamp
-            //1a1. Return if within acceptable timeframe (never check for new Version??)
-            //1a2. Step2 if outside timeframe
-            //1b. if !exists, continue Step2
-            //2. Check for local file
-            //2a. Continue API retrieval if user pref is to always pull new API
-            //2b. If !exists local file, continue API retrieval
-            //2b. If exists local file, check local file timestamp
-            //2b1. Return if within acceptable timeframe (never check for new Version??)
-            //2b2. Step3 if outside timeframe
-            //3. Exists local file + Outside Timeframe
-            //3a. API call for Version
-            //3a1. No Version returned, (ERROR instance: Return local file or continue API retrieval??)
-            //3a2. Version matches local file, return local file
-            //3a3. Version returned ! match local file, continue API retrieval
-            //if (CheckForLocalFile(setName))
-            //    response = GetLocalFileObject();
+            if (!SettingsHelper.SettingIsNullOrEmpty("Definitions_CacheAlwaysNew") && SettingsHelper.UserSettings["Definitions_CacheAlwaysNew"])
+            {
+                //1. Check for object in mem
+                //1a. if exists, check timestamp
+                //1a1. Return if within acceptable timeframe (never check for new Version??)
+                //1a2. Step2 if outside timeframe
+                //1b. if !exists, continue Step2
+                //2. Check for local file
+                //  (Allow user to specify local storage location)
+                //  But follow naming convetion below
+                //  User:    C:\Users\adams\Documents\My Matches\DATABASE\
+                //  System:        DEFINITIONS/[attribute type name]
+                //  System:         filename - v2.0 ntparc Three-Position Air Rifle 3x10.json (colon(:)=space)
+                //2a. Continue API retrieval if user pref is to always pull new API
+                //2b. If !exists local file, continue API retrieval
+                //2b. If exists local file, check local file timestamp
+                //2b1. Return if within acceptable timeframe (never check for new Version??)
+                //2b2. Step3 if outside timeframe
+                //3. Exists local file + Outside Timeframe
+                //3a. API call for Version
+                //3a1. No Version returned, (ERROR instance: Return local file or continue API retrieval??)
+                //3a2. Version matches local file, return local file
+                //3a3. Version returned ! match local file, continue API retrieval
+                //if (CheckForLocalFile(setName))
+                //    response = GetLocalFileObject();
+            }
 
             GetDefinitionRequest requestParameters = new GetDefinitionRequest(setName, type.Description());
 

--- a/BabelFish/Helpers/DefinitionCacheHelper.cs
+++ b/BabelFish/Helpers/DefinitionCacheHelper.cs
@@ -1,4 +1,5 @@
-﻿using BabelFish.DataModel.Definitions;
+﻿using System.Reflection;
+using BabelFish.DataModel.Definitions;
 
 namespace BabelFish.Helpers
 {
@@ -29,17 +30,20 @@ namespace BabelFish.Helpers
             if (!SettingsHelper.SettingIsNullOrEmpty("Definitions_CacheExpireTime"))
                 prefCacheExpireTime = TimeSpan.FromDays(SettingsHelper.UserSettings["Definitions_CacheExpireTime"]);
 
+            //Default directory to UserSettings
             if (!SettingsHelper.SettingIsNullOrEmpty("Definitions_CacheStorageDirctory"))
                 currentFilePath = $"{SettingsHelper.UserSettings["Definitions_CacheStorageDirctory"].TrimEnd('\\')}\\{DEFINITION_DIR}\\";
             else
             {
                 string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                 string subDir = "\\Documents\\My Matches";
+                // 1st default to Orion user directory, 2nd iuser temp directory, fail over to installation directory
                 if (FileHelper.DirectoryExists($"{userDir}{subDir}"))
                     currentFilePath = $"{userDir}{subDir}\\{DEFINITION_DIR}";
-                else
+                else if (FileHelper.DirectoryExists($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\appdata\\local\\temp") )
                     currentFilePath = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\appdata\\local\\temp\\{DEFINITION_DIR}";
-                //currentFilePath = $"{System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\{DEFINITION_DIR}";
+                else
+                    currentFilePath = $"{System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\{DEFINITION_DIR}";
             }
 
             // Load exisitng file system Definitions into memory

--- a/BabelFish/Helpers/DefinitionCacheHelper.cs
+++ b/BabelFish/Helpers/DefinitionCacheHelper.cs
@@ -1,0 +1,434 @@
+﻿using BabelFish.DataModel.Definitions;
+
+namespace BabelFish.Helpers
+{
+    public class DefinitionCacheHelper
+    {
+        private const string DEFINITION_FILE_EXT = ".json";
+        private const string DEFINITION_DIR = "DEFINITIONS";
+        private const int DEFINITION_EXPIRE = 14;
+
+        private List<DefinitionCache> definitionsCached = new List<DefinitionCache>();
+
+        private bool prefDefintionsCacheIgnore = false;
+
+        private TimeSpan prefCacheExpireTime = TimeSpan.FromDays(DEFINITION_EXPIRE);
+
+        private string currentFilePath = string.Empty;
+
+        private SetName? currentSetName = null;
+
+        private Definition.DefinitionType? currentType { get; set; } = null;
+
+        public DefinitionCacheHelper()
+        {
+            // Populate user defaults
+            if (!SettingsHelper.SettingIsNullOrEmpty("Definitions_CacheIgnore"))
+                prefDefintionsCacheIgnore = SettingsHelper.UserSettings["Definitions_CacheIgnore"];
+
+            if (!SettingsHelper.SettingIsNullOrEmpty("Definitions_CacheExpireTime"))
+                prefCacheExpireTime = TimeSpan.FromDays(SettingsHelper.UserSettings["Definitions_CacheExpireTime"]);
+
+            if (!SettingsHelper.SettingIsNullOrEmpty("Definitions_CacheStorageDirctory"))
+                currentFilePath = $"{SettingsHelper.UserSettings["Definitions_CacheStorageDirctory"].TrimEnd('\\')}\\{DEFINITION_DIR}\\";
+            else
+            {
+                string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string subDir = "\\Documents\\My Matches";
+                if (FileHelper.DirectoryExists($"{userDir}{subDir}"))
+                    currentFilePath = $"{userDir}{subDir}\\{DEFINITION_DIR}";
+                else
+                    currentFilePath = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\appdata\\local\\temp\\{DEFINITION_DIR}";
+                //currentFilePath = $"{System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\{DEFINITION_DIR}";
+            }
+
+            // Load exisitng file system Definitions into memory
+            if ( !prefDefintionsCacheIgnore)
+                LoadDefinitionsInMemory();
+        }
+
+        #region Properties
+        public string LastException { get; private set; } = string.Empty;
+
+        public string DefaultDirectory { get { return currentFilePath; } }
+
+        public SetName? CurrentSetName { get { return currentSetName; } }
+
+        public Definition.DefinitionType? CurrentType { get { return currentType; } }
+        #endregion Properties
+
+        #region Methods
+        /// <summary>
+        /// Retrieve Defintion from Cache
+        /// </summary>
+        /// <param name="definitionType"></param>
+        /// <param name="setName"></param>
+        /// <returns>DefinitionCache object or null if not available</returns>
+        public DefinitionCache? GetCachedDefinition(Definition.DefinitionType definitionType, SetName setName)
+        {
+            LastException = string.Empty;
+            SetCurrent(definitionType, setName);
+
+            DefinitionCache returnDefinitionCache = null;
+            try
+            {
+                if (!prefDefintionsCacheIgnore)
+                    returnDefinitionCache = GetDefinitionFromCache();
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error getting cached definition: {ex.Message}";
+            }
+
+            return returnDefinitionCache;
+        }
+
+        /// <summary>
+        /// Age of Definition Cache in Days
+        /// </summary>
+        /// <param name="definitionType"></param>
+        /// <param name="setName"></param>
+        /// <returns>INTEGER (0+ days); -1 denotes error in LastException</returns>
+        public int DefinitionCacheAgeInDays(Definition.DefinitionType definitionType, SetName setName)
+        {
+            LastException = string.Empty;
+            SetCurrent(definitionType, setName);
+            try
+            {
+                return (int)DefinitionCacheAge().TotalDays;
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error getting Definition Cache Age: {ex.Message}";
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Save Definition to all cache sources
+        /// </summary>
+        /// <param name="setDefinition"></param>
+        /// <returns>true or false with exception</returns>
+        public bool SaveDefinitionToCache(string saveDefinition, Definition.DefinitionType definitionType, SetName setName)
+        {
+            LastException = string.Empty;
+            SetCurrent(definitionType, setName);
+            bool returnSave = false;
+            try
+            {
+                DefinitionCache convertDefinition = new DefinitionCache();
+                convertDefinition.SetName = this.currentSetName;
+                convertDefinition.DefinitionType = this.currentType;
+                convertDefinition.DefinitionJSON = saveDefinition;
+                convertDefinition.LastUpdated = DateTime.Now;
+                if (WriteDefinitionToMemory(convertDefinition) &&
+                        WriteDefinitionToFileSystem(convertDefinition))
+                    return true;
+            }
+            catch (Exception ex)
+            {
+                LastException = ex.Message;
+            }
+            return returnSave;
+        }
+
+        /// <summary>
+        /// Retrieve non-expired Definition from all sources (memory/file system)
+        /// </summary>
+        /// <returns>DefinitionCache object or NULL if not found/expired</returns>
+        private DefinitionCache? GetDefinitionFromCache()
+        {
+            DefinitionCache returnDefinitionCache = null;
+            try
+            {
+                // Check Memory
+                returnDefinitionCache = GetDefinitionFromMemory();
+                if (returnDefinitionCache == null && LastException == String.Empty)
+                {
+                    // Check File System
+                    returnDefinitionCache = GetDefinitionCacheFile(currentSetName.FileName);
+                    if (returnDefinitionCache != null)
+                        WriteDefinitionToMemory(returnDefinitionCache);
+                }
+
+                // Check Version on expired Definition Cache
+                if (returnDefinitionCache != null && DefinitionCacheExpired(returnDefinitionCache))
+                {
+                    string stringVersion = JsonHelper.FieldValueFromJson(returnDefinitionCache.DefinitionJSON, "Version");
+                    //When .M is 0, it means to pull the latest version.
+                    int cacheVersionM = int.Parse(stringVersion.Split('.')[1]);
+                    float cacheVersion = float.Parse(stringVersion);
+                    float serverVersion = GetDefinitionVersionFromServer(currentType, currentSetName);
+                    
+                    if (cacheVersionM == 0 ||
+                            serverVersion > cacheVersion)
+                        returnDefinitionCache = null; //force fresh download
+                }
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error retrieving Defintion Cache: {ex.Message}";
+            }
+
+            return returnDefinitionCache;
+        }
+
+        /// <summary>
+        /// Retrieve Definition from memory
+        /// </summary>
+        /// <param name="getType"></param>
+        /// <param name="getSetName"></param>
+        /// <returns>DefinitionCache object or null if not found</returns>
+        private DefinitionCache? GetDefinitionFromMemory()
+        {
+            LastException = string.Empty;
+            DefinitionCache returnDefinition = null;
+            try
+            {
+                returnDefinition = definitionsCached.Where(x => x.DefinitionType.ToString() == this.currentType.ToString() && 
+                                                            x.SetName.ToString() == this.currentSetName.ToString()).FirstOrDefault();
+            }
+            catch (Exception ex)
+            {
+                LastException = ex.Message;
+            }
+
+            return returnDefinition;
+        }
+
+        /// <summary>
+        /// Save Definiton Cache in Memory
+        /// </summary>
+        /// <param name="writeDefinition"></param>
+        /// <returns>true or false</returns>
+        private bool WriteDefinitionToMemory(DefinitionCache writeDefinition)
+        {
+            List<DefinitionCache> updateCache = new List<DefinitionCache>();
+            try
+            {
+                foreach (DefinitionCache copyDefinition in definitionsCached)
+                    updateCache.Add(copyDefinition.DeepCopy(copyDefinition));
+
+                definitionsCached.Clear();
+                foreach (DefinitionCache item in updateCache)
+                {
+                    if (item.SetName.ToString() == writeDefinition.SetName.ToString())
+                        definitionsCached.Add(item.DeepCopy(writeDefinition));
+                    else
+                        definitionsCached.Add(item.DeepCopy(item));
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error updating Definition Cache Memoery: {ex.Message}";
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Save Definiton Cache in File System
+        /// </summary>
+        /// <param name="writeDefinition"></param>
+        /// <returns>true or false</returns>
+        private bool WriteDefinitionToFileSystem(DefinitionCache writeDefinition)
+        {
+            bool returnWriteSuccess = false;
+            try
+            {
+                if ( EnsureWriteDirectory() )
+                    returnWriteSuccess = FileHelper.FileContentsWrite(writeDefinition.DefinitionJSON, writeDefinition.SetName.FileName, currentFilePath);
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error writing Definition to file system: {ex.Message}";
+            }
+
+            return returnWriteSuccess;
+        }
+
+        /// <summary>
+        /// Creates directory to write if !exists
+        /// </summary>
+        /// <param name="DirectoryPath"></param>
+        private bool EnsureWriteDirectory()
+        {
+            try
+            {
+                if (!FileHelper.DirectoryExists($"{currentFilePath}"))
+                    FileHelper.DirectoryCreate($"{currentFilePath}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error creating Definition Cache directory: {ex.Message}";
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Age of given Definition Cache
+        /// </summary>
+        /// <param name="definitionType"></param>
+        /// <param name="setName"></param>
+        /// <returns>Local Definition Age of type Timespan. Convert with .TotalDays</returns>
+        private TimeSpan DefinitionCacheAge(Definition.DefinitionType? definitionType = null, SetName? setName = null)
+        {
+            SetCurrent(definitionType, setName);
+            LastException = string.Empty;
+            TimeSpan returnDefinitionCacheAge = TimeSpan.Zero;
+            try
+            {
+                var checkLastUpdated = DefinitionCacheLastUpdated();
+                if ( checkLastUpdated != null )
+                    returnDefinitionCacheAge = DateTime.Now.Subtract(checkLastUpdated);
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error: {ex.Message}";
+            }
+
+            return returnDefinitionCacheAge;
+        }
+
+        /// <summary>
+        /// LastUpdated date for Current Type/SetName
+        /// </summary>
+        /// <returns>DateTime</returns>
+        private DateTime DefinitionCacheLastUpdated(Definition.DefinitionType? definitionType = null, SetName? setName = null)
+        {
+            SetCurrent(definitionType, setName);
+            LastException = string.Empty;
+            DateTime returnDateTime = new DateTime();
+            DefinitionCache? checkDefinition = null;
+            try
+            {
+                checkDefinition = definitionsCached.Where(x => x.DefinitionType.ToString() == this.currentType.ToString() && x.SetName.ToString() == this.currentSetName.ToString()).FirstOrDefault();
+                if (checkDefinition != null)
+                    returnDateTime = checkDefinition.LastUpdated;
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error: {ex.Message}";
+            }
+            return returnDateTime;
+        }
+
+        /// <summary>
+        /// Check if Definition has expired based on preference/default setting
+        /// </summary>
+        /// <param name="definitionCache"></param>
+        /// <returns>true or false</returns>
+        private bool DefinitionCacheExpired(DefinitionCache definitionCache)
+        {
+            if (definitionCache.LastUpdated.Subtract(DateTime.Now) > prefCacheExpireTime)
+                return true;
+            else
+                return false;
+        }
+
+        /// <summary>
+        /// Load Definitions from file system into memory
+        /// </summary>
+        private void LoadDefinitionsInMemory()
+        {
+            foreach (string definitionFile in ListDefinitionFileNames())
+                definitionsCached.Add(GetDefinitionCacheFile(definitionFile));
+        }
+
+        /// <summary>
+        /// List of filenames in the definition cache filesystem folder
+        /// </summary>
+        /// <returns>String list of file names</returns>
+        private List<string> ListDefinitionFileNames()
+        {
+            List<string> returnDefinitionFileNames = new List<string>();
+            try
+            {
+                returnDefinitionFileNames = FileHelper.ListFilesInDirectory(currentFilePath);
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error fetching definition file list: {ex.Message}";
+            }
+
+            return returnDefinitionFileNames;
+        }
+
+        /// <summary>
+        /// Fetch and parse definition file from file system
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns>DefinitionCache object generated from json</returns>
+        private DefinitionCache GetDefinitionCacheFile(string fileName)
+        {
+            DefinitionCache returnDefinitionCache = null;
+            try
+            {
+                if (File.Exists($"{currentFilePath}\\{fileName}"))
+                {
+                    returnDefinitionCache = new DefinitionCache();
+                    returnDefinitionCache.DefinitionJSON = FileHelper.FileContentsGet(fileName, currentFilePath);
+                    returnDefinitionCache.LastUpdated = FileHelper.FileInfo(fileName, currentFilePath).LastWriteTime;
+
+                    returnDefinitionCache.SetName = SetName.Parse(JsonHelper.FieldValueFromJson(returnDefinitionCache.DefinitionJSON, "SetName"));
+
+                    // Need to match Enum.Description returned in json
+                    returnDefinitionCache.DefinitionType = EnumHelper.ParseEnumByDescription<Definition.DefinitionType>(JsonHelper.FieldValueFromJson(returnDefinitionCache.DefinitionJSON, "Type"));
+                }
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Error loading definition file: {ex.Message}";
+            }
+            return returnDefinitionCache;
+        }
+
+        private float GetDefinitionVersionFromServer(Definition.DefinitionType? definitionType, SetName? setName)
+        {
+            float returnVersion = -1;
+
+            if ( definitionType!=null && setName != null)
+            {
+                HttpResponseMessage response = new HttpResponseMessage();
+                string url = $"https://api-stage.orionscoringsystem.com/production/definition/{definitionType}/{setName}?version=true";
+                try
+                {
+                    HttpRequestMessage msg;
+                    msg = new HttpRequestMessage(HttpMethod.Get, url);
+                    msg.Headers.Host = msg.RequestUri.Host;
+                    msg.Headers.Add("x-api-key", SettingsHelper.UserSettings[AuthEnums.XApiKey.ToString()]);
+                    response = httpClient.SendAsync(msg).Result;
+                    if (float.TryParse(JsonHelper.FieldValueFromJson(JsonHelper.ToJsonString(response), "Version"), out float tryFloat))
+                        returnVersion = tryFloat;
+                }
+                catch (Exception ex)
+                {
+                    LastException = $"Error retrieving Definition Version from server: {ex.Message}";
+                }
+
+            }
+            else
+            {
+                LastException = $"Error getting Definition Version. DefinitionType and SetName cannot be null.";
+            }
+
+            return returnVersion;
+        }
+
+        /// <summary>
+        /// Set local Type and SetName so we don't have to pass them around everywhere
+        /// </summary>
+        /// <param name="setType"></param>
+        /// <param name="setSetName"></param>
+        private void SetCurrent(Definition.DefinitionType? setType, SetName? setSetName)
+        {
+            if ( setType != null )
+                currentType = setType;
+            if ( setSetName != null )
+                currentSetName = setSetName;
+        }
+
+        #endregion Methods
+    }
+}

--- a/BabelFish/Helpers/EnumHelper.cs
+++ b/BabelFish/Helpers/EnumHelper.cs
@@ -181,5 +181,30 @@ namespace BabelFish.Helpers
 
             return JsonConvert.DeserializeObject<T>( JsonConvert.SerializeObject( source ), deserializeSettings );
         }
+
+        /// <summary>
+        /// Retrieve <T>Enum matching Description text
+        /// https://stackoverflow.com/questions/10955517/get-enum-value-by-description
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static T ParseEnumByDescription<T>(this string value) 
+        {
+            T returnEnum = default(T);
+            foreach (var field in typeof(T).GetFields())
+            {
+                var attr = Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) as DescriptionAttribute;
+                if ( attr != null)
+                {
+                    if ( attr.Description == value)
+                    {
+                        returnEnum = (T)field.GetValue(null);
+                        break;
+                    }
+                }
+            }
+            return returnEnum;
+        }
     }
 }

--- a/BabelFish/Helpers/FileHelper.cs
+++ b/BabelFish/Helpers/FileHelper.cs
@@ -1,0 +1,185 @@
+﻿using System.Reflection;
+using System.Configuration;
+using BabelFish.DataModel;
+using BabelFish.DataModel.Definitions;
+using System.Collections.Specialized;
+
+namespace BabelFish.Helpers
+{
+    static class FileHelper
+    {
+        private static string BaseFilePath = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+        public static string LastException { get; set; } = string.Empty;
+
+        static FileHelper() { }
+
+        /// <summary>
+        /// Check if file exists
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="altPath"></param>
+        /// <returns></returns>
+        public static bool FileExists(string fileName, string altPath = "")
+        {
+            LastException = string.Empty;
+            try
+            {
+                return File.Exists($"{(String.IsNullOrEmpty(altPath) ? BaseFilePath : altPath)}\\{fileName}");
+            }
+            catch(Exception ex)
+            {
+                LastException = $"File Exists Error: {ex.Message}";
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Check if Directory exists
+        /// </summary>
+        /// <param name="directoryPath"></param>
+        /// <returns></returns>
+        public static bool DirectoryExists(string directoryPath)
+        {
+            LastException = string.Empty;
+            try
+            {
+                return Directory.Exists(directoryPath);
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Directory Exists Error: {ex.Message}";
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Create Directory
+        /// </summary>
+        /// <param name="directoryPath"></param>
+        /// <returns></returns>
+        public static bool DirectoryCreate(string directoryPath)
+        {
+            LastException = string.Empty;
+            try
+            {
+                if ( !DirectoryExists(directoryPath) )
+                    Directory.CreateDirectory(directoryPath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LastException = $"Directory Create Error: {ex.Message}";
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// List of files in a directory
+        ///     If no directory, uses BaseFilePath
+        /// </summary>
+        /// <param name="directoryToList"></param>
+        /// <returns></returns>
+        public static List<string> ListFilesInDirectory(string directoryToList, bool returnFullPath = false)
+        {
+            LastException = string.Empty;
+            List<string> returnList = new List<string>();
+            try
+            {
+                if (string.IsNullOrEmpty(directoryToList))
+                    directoryToList = $"{BaseFilePath}";
+                if (Directory.Exists(directoryToList))
+                {
+                    string[] fileList = Directory.GetFiles(directoryToList);
+                    if (fileList.Length > 0)
+                    {
+                        foreach (string fileName in fileList)
+                        {
+                            if (returnFullPath)
+                                returnList.Add(fileName);
+                            else
+                                returnList.Add(Path.GetFileName(fileName));
+                        }
+                    }
+                }
+            }
+            catch(Exception ex)
+            {
+                LastException = $"Directory File List Error: {ex.Message}";
+            }
+
+            return returnList;
+        }
+
+        /// <summary>
+        /// Retrieve contents of file
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="altPath"></param>
+        /// <returns></returns>
+        public static string FileContentsGet(string fileName, string altPath = "")
+        {
+            string returnFileContents = string.Empty;
+            LastException = string.Empty;
+            try
+            {
+                if ( FileExists(fileName, altPath))
+                {
+                   returnFileContents = System.IO.File.ReadAllText(BuildFileNamePath(fileName, (String.IsNullOrEmpty(altPath) ? BaseFilePath : altPath)));
+                }
+            }
+            catch (Exception ex)
+            {
+                LastException = $"File Contents Error: {ex.Message}";
+            }
+
+            return returnFileContents;
+        }
+
+        /// <summary>
+        /// Write contents to file
+        /// </summary>
+        /// <param name="fileContent"></param>
+        /// <param name="fileName"></param>
+        /// <param name="altPath"></param>
+        /// <returns></returns>
+        public static bool FileContentsWrite(string fileContent, string fileName, string altPath = "")
+        {
+            bool returnFileContentsWrite = false;
+            LastException = string.Empty;
+            try
+            {
+                System.IO.File.WriteAllText(BuildFileNamePath(fileName, (String.IsNullOrEmpty(altPath) ? BaseFilePath : altPath)), fileContent);
+                returnFileContentsWrite = true;
+            }
+            catch (Exception ex)
+            {
+                LastException = $"File Contents Error: {ex.Message}";
+            }
+
+            return returnFileContentsWrite;
+        }
+
+        /// <summary>
+        /// Get File Information
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="altPath"></param>
+        /// <returns></returns>
+        public static System.IO.FileInfo FileInfo(string fileName, string altPath = "")
+        {
+            return new System.IO.FileInfo(BuildFileNamePath(fileName, (String.IsNullOrEmpty(altPath) ? BaseFilePath : altPath)));
+        }
+
+        /// <summary>
+        /// Utility function to craft full file path with filename
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="altPath"></param>
+        /// <returns>string Path/Filename</returns>
+        private static string BuildFileNamePath(string fileName, string altPath = "")
+        {
+            return $"{(String.IsNullOrEmpty(altPath) ? BaseFilePath : altPath)}\\{fileName}";
+        }
+    }
+}

--- a/BabelFish/Helpers/JsonHelper.cs
+++ b/BabelFish/Helpers/JsonHelper.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace BabelFish.Helpers
 {
@@ -25,6 +26,39 @@ namespace BabelFish.Helpers
                 default:
                     return ((JValue)token).Value;
             }
+        }
+
+        public static string ToJsonString(HttpResponseMessage response) 
+        {
+            using (Stream s = response.Content.ReadAsStreamAsync().Result)
+            using (StreamReader sr = new StreamReader(s))
+            using (JsonReader reader = new JsonTextReader(sr))
+            {
+                return JObject.ReadFrom(reader).ToString();
+            }
+        }
+
+        public static string FieldValueFromJson(string stringJson, string fieldName)
+        {
+            string returnValue = string.Empty;
+            List<string> ignoreNames = new List<string>() { "Title", "Message", "ResponseCodes" };
+
+            JObject o = JObject.Parse(stringJson);
+            string otype = o.Type.ToString();
+            foreach (JProperty property in o.Properties())
+            {
+                if (!ignoreNames.Contains(property.Name))
+                {
+                    JObject o2 = JObject.Parse(property.Value.ToString());
+                    foreach (JProperty property2 in o2.Properties())
+                    {
+                        if ( property2.Name == fieldName)
+                            returnValue = property2.Value.ToString();
+                    }
+                }
+            }
+
+            return returnValue;
         }
     }
 }

--- a/BabelFish/Helpers/SettingsHelper.cs
+++ b/BabelFish/Helpers/SettingsHelper.cs
@@ -17,20 +17,22 @@ namespace BabelFish.Helpers
         /// </summary>
         private static Dictionary<string, Type> AllowedSettings = new Dictionary<string, Type>()
         {
-            { "UserName", typeof(string) },                 // User Name to validate AWS access
-            { "PassWord", typeof(string) },                 // User Password to validate AWS access
-            { "AccessKey", typeof(string) },                // User AccessKey for valid AWS access
-            { "SecretKey", typeof(string) },                // User SecretKey for valid AWS access
-            { "SessionToken", typeof(string) },             // User SessionToken for valid AWS access
+            { "UserName", typeof(string) },                             // User Name to validate AWS access
+            { "PassWord", typeof(string) },                             // User Password to validate AWS access
+            { "AccessKey", typeof(string) },                            // User AccessKey for valid AWS access
+            { "SecretKey", typeof(string) },                            // User SecretKey for valid AWS access
+            { "SessionToken", typeof(string) },                         // User SessionToken for valid AWS access
 
-            { "RefreshToken", typeof(string) },             // Cognito Refresh Token for valid AWS access
-            { "IdToken", typeof(string) },                 // Cognito ID Token for valid AWS access
-            { "AccessToken", typeof(string) },              // Cognito Access Token for valid AWS access
-            { "DeviceToken", typeof(string) },                 // Cognito Device ID for valid AWS access
+            { "RefreshToken", typeof(string) },                         // Cognito Refresh Token for valid AWS access
+            { "IdToken", typeof(string) },                              // Cognito ID Token for valid AWS access
+            { "AccessToken", typeof(string) },                          // Cognito Access Token for valid AWS access
+            { "DeviceToken", typeof(string) },                          // Cognito Device ID for valid AWS access
 
-            { "Logging_NLogConfig", typeof(string) },       // Alternate NLog path/filename
-            { "Definitions_CacheAlwaysNew", typeof(bool) }, // Definitions cache override to always fetch new
-            { "XApiKey", typeof(string) },                  // User XApiKey passed in
+            { "Logging_NLogConfig", typeof(string) },                   // Alternate NLog path/filename
+            { "Definitions_CacheIgnore", typeof(bool) },                // Definitions cache override to always fetch new
+            { "Definitions_CacheExpireTime", typeof(int) },             // Definitions cache expire time in days
+            { "Definitions_CacheStorageDirctory", typeof(string) },     // Definitions cache storage directory
+            { "XApiKey", typeof(string) },                              // User XApiKey passed in
         };
 
         /// <summary>
@@ -138,7 +140,7 @@ namespace BabelFish.Helpers
 
         public static bool SettingIsNullOrEmpty(string settingName)
         {
-            if ((UserSettings.ContainsKey(settingName)) && UserSettings[settingName] == null || UserSettings[settingName] == string.Empty)
+            if ((UserSettings.ContainsKey(settingName)) && UserSettings[settingName] == null || UserSettings[settingName].ToString() == string.Empty)
                 return true;
             else
                 return false;

--- a/BabelFish/README.md
+++ b/BabelFish/README.md
@@ -81,6 +81,13 @@ MessageResponse.Message holds error Message returned from API List
 
 
 =============================== BabelFish Versioning
+v1.0.10.0
+Implement Definition Caching in local memory/file system
+Add UserSettings values to control cache functionality
+
+v1.0.9.0
+Add Get and Set Attribute Value functionality
+
 v1.0.8.0
 Implement Cognito Authentication on the back end via username/password retrieving RefreshToken, IdToken, AccessToken, DeviceToken.
 Add ApiClient GetAuthTokens() and UpdateAuthTokens() to retrieve/reset authentication tokens in a single session.


### PR DESCRIPTION
Definition Cache in local memory/file system ready for review. 
I believe all the requirements were achieved.
Please reach out if you want a walk-through the code or find any problems or want anything refactored.

All this is transparent to the user except for the new UserSettings passed in to control DefinitionCache functionality.
- Unit Tests created for functionality. ATTRIBUTE, COURSEOFFIRE tests for different types saved to memory/file.
- Confirmed GetReconfigurableRulebookDefinitionTests successfully save Definitions as they use the same function call. 
- Default directory: uses UserSettings(below) if set, otherwise first checks for user's Orion My Matches dir then fails over to user's temp dir, storing them in a DEFINITIONS sub directory by SetName.filename.
- New UserSettings are: 
   Definitions_CacheIgnore(true/false, default=false if absent)
   Definitions_CacheExpireTime(int for days, default=14 if absent)
   Definitions_CacheStorageDirctory(string of preferred storage directory, default noted above)