### PR TITLE
GetVersion() build out v1.0.11

### DIFF
--- a/BabelFish.Tests/MiscTests.cs
+++ b/BabelFish.Tests/MiscTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Net;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BabelFish.GetVersionAPI;
+using BabelFish.Helpers;
+
+namespace BabelFish.Tests {
+    [TestClass]
+    public class MiscTests {
+        private static string xApiKey = "wjM7eCb75aa3Okxj4FliXLY0VjHidoE2ei18pdg1";
+        private readonly GetVersionAPIClient _client = new GetVersionAPIClient(xApiKey);
+
+        [TestMethod]
+        public void GetOrionServiceProductionLevel()
+        {
+            VersionService service = VersionService.orion;
+            VersionLevel level = VersionLevel.production;
+            var response = _client.GetVersionAsync(service, level);
+
+            var result = response.Result;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.StatusCode, HttpStatusCode.OK);
+            Assert.AreEqual(result.VersionList.Count, 1);
+            Assert.AreEqual(result.VersionList[0].Service, service);
+
+            var MessageResponse = response.Result.MessageResponse;
+            Assert.IsTrue(MessageResponse.Message.Count == 0);
+        }
+
+        [TestMethod]
+        public void GetAthenaServiceAlphaLevel()
+        {
+            VersionService service = VersionService.athena;
+            VersionLevel level = VersionLevel.alpha;
+            var response = _client.GetVersionAsync(service, level);
+
+            var result = response.Result;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.StatusCode, HttpStatusCode.OK);
+            Assert.AreEqual(result.VersionList.Count, 1);
+            Assert.AreEqual(result.VersionList[0].Service, service);
+
+            var MessageResponse = response.Result.MessageResponse;
+            Assert.IsTrue(MessageResponse.Message.Count == 0);
+        }
+
+        [TestMethod]
+        public void GetMultipleServicesProductionLevel()
+        {
+            List<VersionService> services = new List<VersionService>() { VersionService.orion, VersionService.athena };
+            VersionLevel level = VersionLevel.production;
+            var response = _client.GetVersionAsync(services, level);
+
+            var result = response.Result;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.StatusCode, HttpStatusCode.OK);
+            Assert.AreEqual(result.VersionList.Count, 2);
+            Assert.IsTrue(result.VersionList.Any(x => x.Service == VersionService.athena));
+
+            var MessageResponse = response.Result.MessageResponse;
+            Assert.IsTrue(MessageResponse.Message.Count == 0);
+        }
+
+    }
+}

--- a/BabelFish/BabelFish.csproj
+++ b/BabelFish/BabelFish.csproj
@@ -5,9 +5,9 @@
 	  <LangVersion>latest</LangVersion>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <Nullable>enable</Nullable>
-    <AssemblyVersion>1.0.8.0</AssemblyVersion>
+    <AssemblyVersion>1.0.11.0</AssemblyVersion>
 	<PackageId>BabelFish</PackageId>
-	<Version>1.0.8</Version>
+	<Version>1.0.11</Version>
 	<Authors>Shooter's Technology</Authors>
 	<Company>Shooter's Technology</Company>
 	<PackageDescription>Dot Net Library that provides a façade for Shooter's Tech REST API interface.</PackageDescription>

--- a/BabelFish/DataModel/Misc/Version.cs
+++ b/BabelFish/DataModel/Misc/Version.cs
@@ -1,0 +1,46 @@
+﻿using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using BabelFish.Helpers;
+
+namespace BabelFish.DataModel.Misc
+{
+    public class VersionsList {
+        public List<VersionInfo> Versions = new List<VersionInfo>();
+    }
+
+    [Serializable]
+    public class VersionInfo
+    {
+        [JsonProperty(Order = 1)]
+        public string Version { get; set; } = string.Empty;
+
+        [JsonProperty(Order = 2)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public VersionService Service { get; set; }
+
+        [JsonProperty(Order = 3)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public VersionLevel Level { get; set; }
+
+        [JsonProperty(Order = 4)]
+        public List<string> ReleaseNotes { get; set; } = new List<string>();
+
+        [JsonProperty(Order = 5)]
+        public List<string> Enhancements { get; set; } = new List<string>();
+
+        [JsonProperty(Order = 6)]
+        public List<string> BugFixes { get; set; } = new List<string>();
+
+        [JsonProperty(Order = 7)]
+        public DateTime Datetime { get; set; } = new DateTime();
+
+        public override string ToString()
+        {
+            StringBuilder foo = new StringBuilder();
+            foo.Append("Version ");
+            foo.Append(Version);
+            return foo.ToString();
+        }
+    }
+}

--- a/BabelFish/GetVersionAPIClient.cs
+++ b/BabelFish/GetVersionAPIClient.cs
@@ -1,0 +1,55 @@
+﻿using BabelFish.Requests.Misc;
+using BabelFish.Responses.Misc;
+using BabelFish.Helpers;
+
+namespace BabelFish.GetVersionAPI
+{
+    public class GetVersionAPIClient : APIClient {
+
+        /// <summary>
+        /// Instantiate client
+        /// </summary>
+        /// <param name="apiKey"></param>
+        public GetVersionAPIClient(string apiKey) : base(apiKey) { }
+
+        /// <summary>
+        /// Instantiate client
+        /// </summary>
+        /// <param name="xapikey">Your assigned XApiKey</param>
+        /// <param name="CustomUserSettings">Dictionary<string,string> of Allowed User Settings</param>
+        public GetVersionAPIClient(string xapikey, Dictionary<string, string> CustomUserSettings) : base(xapikey, CustomUserSettings) { }
+
+        /// <summary>
+        /// GetVersion API for multiple services
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="level"></param>
+        /// <returns>VersionList object</returns>
+        public async Task<GetVersionResponse> GetVersionAsync(List<VersionService> services, VersionLevel level) {
+
+            GetVersionResponse response = new GetVersionResponse();
+
+            GetVersionRequest requestParameters = new GetVersionRequest(services, level);
+
+            await this.CallAPI(requestParameters, response).ConfigureAwait(false);
+
+            return response;
+        }
+
+        /// <summary>
+        /// GetVersion API for one service
+        /// </summary>
+        /// <param name="service"></param>
+        /// <param name="level"></param>
+        /// <returns>VersionList object</returns>
+        public async Task<GetVersionResponse> GetVersionAsync(VersionService service, VersionLevel level)
+        {
+            GetVersionResponse response = new GetVersionResponse();
+
+            response = await GetVersionAsync(new List<VersionService>() { service }, level).ConfigureAwait(false);
+
+            return response;
+        }
+
+    }
+}

--- a/BabelFish/Helpers/EnumHelper.cs
+++ b/BabelFish/Helpers/EnumHelper.cs
@@ -126,6 +126,12 @@ namespace BabelFish.Helpers
         INTERNAL_STAGE
     }
 
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum VersionService { none, orion, athena }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum VersionLevel { none, alpha, beta, production }
+
     public static class EnumHelper
     {
         /// <summary>

--- a/BabelFish/README.md
+++ b/BabelFish/README.md
@@ -81,6 +81,9 @@ MessageResponse.Message holds error Message returned from API List
 
 
 =============================== BabelFish Versioning
+v1.0.11.0
+Add GetVersionAPI -> GetVersion() with VersionService, VersionLevel Enum helpers
+
 v1.0.8.0
 Implement Cognito Authentication on the back end via username/password retrieving RefreshToken, IdToken, AccessToken, DeviceToken.
 Add ApiClient GetAuthTokens() and UpdateAuthTokens() to retrieve/reset authentication tokens in a single session.

--- a/BabelFish/Requests/Misc/GetVersionRequest.cs
+++ b/BabelFish/Requests/Misc/GetVersionRequest.cs
@@ -1,0 +1,35 @@
+﻿using BabelFish.Helpers;
+
+namespace BabelFish.Requests.Misc
+{
+    public class GetVersionRequest : Request
+    {
+        private const string ParamName = "services";
+        private Dictionary<string, List<string>> queryParameters = new Dictionary<string, List<string>>();
+
+        public GetVersionRequest(List<VersionService> services, VersionLevel level)
+        {
+
+            queryParameters.Add(ParamName, new List<string>());
+            services.ForEach(x => queryParameters[ParamName].Add(x.ToString()));
+
+            queryParameters.Add("level", new List<string>());
+            queryParameters["level"].Add(level.ToString());
+        }
+
+        /// <inheritdoc />
+        public override string RelativePath
+        {
+            get { return $"/version"; }
+        }
+
+        public override Dictionary<string, List<string>> QueryParameters
+        {
+            get
+            {
+                return queryParameters;
+            }
+        }
+
+    }
+}

--- a/BabelFish/Responses/Misc/GetVersionResponse.cs
+++ b/BabelFish/Responses/Misc/GetVersionResponse.cs
@@ -1,0 +1,16 @@
+﻿using BabelFish.DataModel.Misc;
+using Newtonsoft.Json.Linq;
+
+namespace BabelFish.Responses.Misc
+{
+    public class GetVersionResponse : Response<VersionsList>
+    {
+        /// <summary>
+        /// Facade function that returns the same as this.Value
+        /// </summary>
+        public List<VersionInfo> VersionList
+        {
+            get { return Value.Versions; }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/shooterstech/BabelFish/issues/23

GetVersionAPI build out for review.
I didn't want the naming "Misc" structure out front but used on the backend for these functions.
GetVersionAPI() workflow is exposed to user for a consistent naming convention.
Added Enums for VersionService and VersionLevel so we accept positively named params.
UnitTests for submission of single or multiple "services" param and different levels.

NOTE: .csproj versioning may conflict with GetSetAttributeValue Pull request. Please include versioning 1.0.9, 1.0.10, 1.0.11 in main merge.