### PR TITLE
Add Participant and Match Metadata to Result List

### DIFF
--- a/BabelFish/BabelFish.csproj
+++ b/BabelFish/BabelFish.csproj
@@ -5,9 +5,9 @@
 	  <LangVersion>latest</LangVersion>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <Nullable>enable</Nullable>
-    <AssemblyVersion>1.5.1.9</AssemblyVersion>
+    <AssemblyVersion>1.5.4.2</AssemblyVersion>
 	<PackageId>Scopos.BabelFish</PackageId>
-	<Version>1.5.1.9</Version>
+	<Version>1.5.4.2</Version>
 	<Authors>Scopos</Authors>
 	<Company>Scopos</Company>
 	<PackageDescription>Dot Net Library that provides a façade for Shooter's Tech REST API interface.</PackageDescription>

--- a/BabelFish/DataModel/OrionMatch/ResultCOF.cs
+++ b/BabelFish/DataModel/OrionMatch/ResultCOF.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Scopos.BabelFish.Converters;
 
 namespace Scopos.BabelFish.DataModel.OrionMatch
 {
@@ -92,10 +93,10 @@ namespace Scopos.BabelFish.DataModel.OrionMatch
         /// <summary>
         /// The Local Date that this score was shot. 
         /// NOTE Local Date is not necessarily the same as the GMT date.
-        /// Formatted as yyyy-MM-dd
         /// </summary>
         [JsonProperty(Order = 14)]
-        public string LocalDate { get; set; } = string.Empty;
+		[JsonConverter( typeof( DateConverter ) )]
+		public DateTime LocalDate { get; set; } = DateTime.Today;
 
         /// <summary>
         /// FUTURE, INTERMEDIATE, UNOFFICIAL, OFFICIAL

--- a/BabelFish/DataModel/OrionMatch/ResultEvent.cs
+++ b/BabelFish/DataModel/OrionMatch/ResultEvent.cs
@@ -22,7 +22,13 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 		/// </summary>
 		public Participant Participant { get; set; } = new Individual();
 
-        [Obsolete("Use .Participant.DisplayName instead.")]
+		/// <summary>
+		/// The local Match ID that generated this ResultEvent.
+		/// Information on that match may be looked up in the ResultList's Metadata field.
+		/// </summary>
+		public string MatchID { get; set; }
+
+		[Obsolete("Use .Participant.DisplayName instead.")]
 		public string DisplayName { get; set; }
 
         [Obsolete("Field is being replaced with the ScoreFormatCollectionDef and ScoreConfigName values. ScoreFormatCollectionDef is found using the CoruseOfFireDef")]

--- a/BabelFish/DataModel/OrionMatch/ResultEvent.cs
+++ b/BabelFish/DataModel/OrionMatch/ResultEvent.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Scopos.BabelFish.Converters;
 
 namespace Scopos.BabelFish.DataModel.OrionMatch {
     [Serializable]
@@ -13,9 +15,15 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             Children = new List<ResultEventChild>();
             //Purposefully set TeamMemebers to null so if it is an individual the attribute doesn't get added into the JSON
             TeamMembers = null;
-        }
+		}
 
-        public string DisplayName { get; set; }
+		/// <summary>
+		/// Data on the person or team who shot this score.
+		/// </summary>
+		public Participant Participant { get; set; } = new Individual();
+
+        [Obsolete("Use .Participant.DisplayName instead.")]
+		public string DisplayName { get; set; }
 
         [Obsolete("Field is being replaced with the ScoreFormatCollectionDef and ScoreConfigName values. ScoreFormatCollectionDef is found using the CoruseOfFireDef")]
         public string ScoreFormat { get; set; }
@@ -38,17 +46,26 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public List<ResultEventChild> Children { get; set; } = new List<ResultEventChild>();
 
         /// <summary>
-        /// The Orion User ID of the athlete. Is blank (empty string) if it is not known or the participant is not a person (and thus likely is a team),
+        /// The Orion User ID of the athlete. Is blank (empty string) if it is not known 
+        /// or the participant is not a person (and thus likely is a team),
         /// </summary>
+        [Obsolete( "Use .Participant.UserID instead.")]
         public string UserID { get; set; } = "";
 
         [Obsolete( "Replaced with EventScores" )]
         public string EventName { get; set; }
 
-        /// <summary>
-        /// If this is a team score, the TeamMembers will be the scores of the team members.If this is an Individual WARNING value will be null.
-        /// </summary>
-        public List<ResultEvent> TeamMembers { get; set; } = new List<ResultEvent>();
+		/// <summary>
+		/// The Local Date that this score was shot. 
+		/// NOTE Local Date is not necessarily the same as the GMT date.
+		/// </summary>
+		[JsonConverter( typeof( DateConverter ) )]
+		public DateTime LocalDate { get; set; } = DateTime.Today;
+
+		/// <summary>
+		/// If this is a team score, the TeamMembers will be the scores of the team members.If this is an Individual WARNING value will be null.
+		/// </summary>
+		public List<ResultEvent> TeamMembers { get; set; } = new List<ResultEvent>();
 
         public Dictionary<string, Scopos.BabelFish.DataModel.OrionMatch.EventScore> EventScores { get; set; }
 

--- a/BabelFish/DataModel/OrionMatch/ResultList.cs
+++ b/BabelFish/DataModel/OrionMatch/ResultList.cs
@@ -17,7 +17,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         }
 
         [JsonProperty( Order = 1 )]
-        public string MatchID { get; set; } = string.Empty;
+		[Obsolete( "Use .Metadata.MatchID" )]
+		public string MatchID { get; set; } = string.Empty;
 
         /// <summary>
         /// Set name of the Ranking Rule definition
@@ -70,7 +71,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public string ResultName { get; set; } = string.Empty;
 
         [JsonProperty( Order = 10 )]
-        public DateTime LastUpdated { get; set; } = new DateTime();
+		[Obsolete( "Use .Metadata.LastUpdated" )]
+		public DateTime LastUpdated { get; set; } = new DateTime();
 
         [JsonProperty( Order = 11 )]
         public string OwnerId { get; set; } = string.Empty;
@@ -113,13 +115,23 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             }
         }
 
-        /// <summary>
-        /// String holding the software (Orion Scoring System) and Version number of the software.
-        /// </summary>
-        public string Creator { get; set; }
+		/// <summary>
+		/// String holding the software (Orion Scoring System) and Version number of the software.
+		/// </summary>
+		[Obsolete( "Use .Metadata.Creator" )]
+		public string Creator { get; set; }
 
-        /// <inheritdoc />
-        public async Task<CourseOfFire> GetCourseOfFireDefinitionAsync() {
+		/// <summary>
+		/// Key is the local match ID.
+		/// Value is the Metadate for the generative match.
+		/// When Orion generates a ResultList there will only be 1 value in Metadata.
+		/// When a Virtual Match is merged, each parent / child ID will be listed.
+		/// Local Matches will have exactly one value.
+		/// </summary>
+		public Dictionary<string, ResultListMetadata> Metadata { get; set; }
+
+		/// <inheritdoc />
+		public async Task<CourseOfFire> GetCourseOfFireDefinitionAsync() {
 
             if (string.IsNullOrEmpty( CourseOfFireDef ))
                 return null;

--- a/BabelFish/DataModel/OrionMatch/ResultListMetadata.cs
+++ b/BabelFish/DataModel/OrionMatch/ResultListMetadata.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Scopos.BabelFish.DataModel.OrionMatch {
+
+	/// <summary>
+	/// Used to describe the match that a ResultEvent was shot at. Instead of each ResultEvent including 
+	/// each of these fields, the ResultEvent references a MatchID, that these fields may be looked up.
+	/// Thus, hopefully, saving space in the already very long Result List.
+	/// </summary>
+	public class ResultListMetadata {
+
+		/// <summary>
+		/// UTC time of last update
+		/// </summary>
+		public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
+
+		/// <summary>
+		/// The location where the match was shot. Usually city and state, e.g. Minden, NE
+		/// </summary>
+		public string MatchLocation { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Unique ID for the match.
+		/// Field may possible be redundant
+		/// </summary>
+		public string MatchID { get; set; } = string.Empty;
+
+		/// <summary>
+		/// String holding the software (Orion Scoring System) and Version number of the software.
+		/// </summary>
+		public string Creator { get; set; } = string.Empty;
+
+		/// <summary>
+		/// The Owner of this data. e.g. OrionAcct001234
+		/// </summary>
+		public string OwnerId { get; set; } = string.Empty;
+
+		/// <summary>
+		/// FUTURE, INTERMEDIATE, UNOFFICIAL, OFFICIAL
+		/// </summary>
+		public string Status { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Name of the TargetCollection used in this match.
+		/// </summary>
+		public string TargetCollectionName { get; set; }
+	}
+}


### PR DESCRIPTION
Add match Metadata to Result List
Adds Participant fields to Result Event

Which is to allow Henchmen to add field options on the Result List Format