### PR TITLE
BarCodeLabel specification.

### DIFF
--- a/src/BabelFish.Reports/BabelFish.Reports.csproj
+++ b/src/BabelFish.Reports/BabelFish.Reports.csproj
@@ -43,7 +43,8 @@
     <PackageReference Include="Svg.Skia" Version="4.6.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+      <!-- May 2026 Upgrading System.Text.Json to 10.0.0 caused downstream issues, especially with Definition Composer. Intentionnally pinned to version 9.0.0 -->
+      <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
     <PackageReference Include="ZXing.Net" Version="0.16.11" />
   </ItemGroup>

--- a/src/BabelFish/BabelFish.csproj
+++ b/src/BabelFish/BabelFish.csproj
@@ -7,9 +7,9 @@
     <!-- Update for only breaking changes (e.g. changes that cause the compiler to error) -->
     <AssemblyVersion>2.0.0</AssemblyVersion>
     <!-- Update with each build -->
-    <FileVersion>2.1.3-beta.6</FileVersion>
+    <FileVersion>2.1.3-beta.8</FileVersion>
     <!-- Updaet with each release, may use -alpha, -beta -->
-    <Version>2.1.3-beta.6</Version>
+    <Version>2.1.3-beta.8</Version>
     <PackageId>Scopos.BabelFish.Core</PackageId>
     <Authors>Scopos LLC</Authors>
     <Company>Scopos LLC</Company>
@@ -45,7 +45,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.0" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+    <!-- May 2026 Upgrading System.Text.Json to 10.0.0 caused downstream issues, especially with Definition Composer -->
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/BabelFish/BabelFish.csproj
+++ b/src/BabelFish/BabelFish.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.0" />
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0" />
-    <!-- May 2026 Upgrading System.Text.Json to 10.0.0 caused downstream issues, especially with Definition Composer -->
+    <!-- May 2026 Upgrading System.Text.Json to 10.0.0 caused downstream issues, especially with Definition Composer. Intentionnally pinned to version 9.0.0 -->
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
   </ItemGroup>

--- a/src/BabelFish/DataActors/Specification/Definitions/CourseOfFireSpecification.cs
+++ b/src/BabelFish/DataActors/Specification/Definitions/CourseOfFireSpecification.cs
@@ -958,8 +958,11 @@ namespace Scopos.BabelFish.DataActors.Specification.Definitions {
 
             var singularLabels = new HashSet<string>();
             singularLabels.Add( string.Empty ); //Add the empty string as an acceptable value
-            foreach (var singular in candidate.Singulars)
-                singularLabels.Add( singular.StageLabel );
+            foreach (var singular in candidate.Singulars) {
+                if (singular.StageLabel is not null) {
+                    singularLabels.Add( singular.StageLabel );
+                }
+            }
 
             var existingNames = new HashSet<string>();
             var index = 0;
@@ -973,7 +976,7 @@ namespace Scopos.BabelFish.DataActors.Specification.Definitions {
                     Messages.Add( $"Each PaperTargetLabel must have a unique name. The name '{ptl.PaperTargetLabelName}' is duplicated." );
                 }
 
-                // Shots per bull must be greater than 0.
+                // Shots per bull must be greater than or equal to 0. Usually 0 is reserved for scorecards.
                 if (ptl.ShotsPerBull < 0) {
                     valid = false;
                     Messages.Add( $"The PaperTargetLabel '{ptl.PaperTargetLabelName}' has ShotsPerBull value of {ptl.ShotsPerBull}. This must be greater than or equal to 0." );

--- a/src/BabelFish/DataActors/Specification/Definitions/CourseOfFireSpecification.cs
+++ b/src/BabelFish/DataActors/Specification/Definitions/CourseOfFireSpecification.cs
@@ -955,6 +955,12 @@ namespace Scopos.BabelFish.DataActors.Specification.Definitions {
                 Messages.Add( "At least one PaperTargetLabel is required if one or more RangeScripts is designed for paper." );
             }
 
+
+            var singularLabels = new HashSet<string>();
+            singularLabels.Add( string.Empty ); //Add the empty string as an acceptable value
+            foreach (var singular in candidate.Singulars)
+                singularLabels.Add( singular.StageLabel );
+
             var existingNames = new HashSet<string>();
             var index = 0;
             foreach (var ptl in candidate.PaperTargetLabels) {
@@ -968,23 +974,18 @@ namespace Scopos.BabelFish.DataActors.Specification.Definitions {
                 }
 
                 // Shots per bull must be greater than 0.
-                if (ptl.ShotsPerBull <= 0) {
+                if (ptl.ShotsPerBull < 0) {
                     valid = false;
-                    Messages.Add( $"The PaperTargetLabel '{ptl.PaperTargetLabelName}' has ShotsPerBull value of {ptl.ShotsPerBull}. This must be greater than 0." );
+                    Messages.Add( $"The PaperTargetLabel '{ptl.PaperTargetLabelName}' has ShotsPerBull value of {ptl.ShotsPerBull}. This must be greater than or equal to 0." );
                 }
 
                 var labelIndex = 0;
                 foreach (var label in ptl.Labels) {
-                    // Each BarcodeLabel must have a non empty StageLabel.
-                    if (string.IsNullOrEmpty( label.StageLabel )) {
+                    // Each BarcodeLabel must have an empty string for a StageLabel, or a value found in a Singular.
+                    if (!singularLabels.Contains( label.StageLabel )) {
                         valid = false;
-                        Messages.Add( $"The PaperTargetLabel '{ptl.PaperTargetLabelName}' has a StageLabel with an empty name." );
-                    }
-
-                    // The StageLabel may only be at most 2 character.
-                    if (label.StageLabel.Length > 2) {
-                        valid = false;
-                        Messages.Add( $"The PaperTargetLabel '{ptl.PaperTargetLabelName}' has a BarcodeLabel with a StageLabel longer than 2 character. StageLabels must be at most 2 characters, and are usually only 1 character." );
+                        var validValues = string.Join( ", ", singularLabels.Select( s => $"'{s}'" ) );
+                        Messages.Add( $"The PaperTargetLabel '{ptl.PaperTargetLabelName}' has a StageLabel with a value not found in any Singular. The acceptable values are: {validValues}." );
                     }
 
                     labelIndex++;

--- a/src/BabelFish/DataModel/Definitions/BarcodeLabel.cs
+++ b/src/BabelFish/DataModel/Definitions/BarcodeLabel.cs
@@ -21,7 +21,9 @@ namespace Scopos.BabelFish.DataModel.Definitions {
         public string StageLabel { get; set; } = string.Empty;
 
         /// <summary>
-        /// The series numbers to print on the barcode labels. Must be formated as a ValueSeries
+        /// The series numbers to print on the barcode labels. Must be formated as a ValueSeries.
+        /// <para>A value > 0 means the bar code label is specific to a series (this is the normal case).
+        /// A value of 0 means the bar code label is generic and can be used for any series.</para>
         /// </summary>
         [DefaultValue( "1" )]
         [G_NS.JsonConverter( typeof( G_BF_NS_CONV.ValueSeriesConverter ) )]

--- a/src/BabelFish/DataModel/Definitions/PaperTargetLabel.cs
+++ b/src/BabelFish/DataModel/Definitions/PaperTargetLabel.cs
@@ -36,6 +36,7 @@ namespace Scopos.BabelFish.DataModel.Definitions {
 
         /// <summary>
         /// The number of shots an athlete should fire per aiming bull and the number of shots the scoring algorithm is expecting to find.
+        /// <para>Value must be greater than or equal to 0. A value of 0 is allowed and usually is reserved for scorecards.</para>
         /// </summary>
         [DefaultValue( 1 )]
         [G_NS.JsonProperty( Order = 2, DefaultValueHandling = G_NS.DefaultValueHandling.Include )]

--- a/tests/BabelFish.Tests/DataModel/DefinitionTests/DefinitionCacheTests.cs
+++ b/tests/BabelFish.Tests/DataModel/DefinitionTests/DefinitionCacheTests.cs
@@ -324,10 +324,12 @@ namespace Scopos.BabelFish.Tests.DataModel.DefinitionTests {
 
         [TestMethod]
         public async Task EriksPlayground() {
-            var setName = SetName.Parse( "v1.0:orion:Test Informal Practice Air Rifle" );
-            var definition = await DefinitionCache.GetDefinitionAsync( DefinitionType.COURSEOFFIRE, setName );
+            var setName = SetName.Parse( "v1.0:orion:Test Attribute" );
+            var definition = await DefinitionCache.GetDefinitionAsync( DefinitionType.ATTRIBUTE, setName );
+            var def2 = await DefinitionCache.GetAttributeDefinitionAsync( setName );
 
-            Assert.AreEqual( DefinitionType.COURSEOFFIRE, definition.Type );
+            Assert.AreEqual( DefinitionType.ATTRIBUTE, definition.Type );
+            Assert.AreEqual( DefinitionType.ATTRIBUTE, def2.Type );
         }
     }
 }

--- a/tests/BabelFish.Tests/DataModel/DefinitionTests/Validation/CourseOfFireValidationTests.cs
+++ b/tests/BabelFish.Tests/DataModel/DefinitionTests/Validation/CourseOfFireValidationTests.cs
@@ -129,6 +129,20 @@ namespace Scopos.BabelFish.Tests.DataModel.Definition.Validation {
             candidate.PaperTargetLabels[0].ShotsPerBull = 1;
             Assert.IsTrue( await validation.IsSatisfiedByAsync( candidate ), string.Join( " : ", validation.Messages ) );
 
+            //This should fail because a coorsponding Singular doesn't exist with a StageLabel of "S"
+            candidate.PaperTargetLabels[0].Labels.Add( new BarcodeLabel() {
+                StageLabel = "S",
+                Series = new ValueSeries( "1" ),
+                LabelSize = BarcodeLabelSize.OL385
+            } );
+            Assert.IsFalse( await validation.IsSatisfiedByAsync( candidate ) );
+
+            // Now shold pass as we have a Singular with a StageLabel of "S"
+            candidate.Singulars.Add( new Singular() {
+                StageLabel = "S",
+            } );
+            Assert.IsTrue( await validation.IsSatisfiedByAsync( candidate ), string.Join( " : ", validation.Messages ) );
+
         }
     }
 }

--- a/tests/BabelFish.Tests/DataModel/DefinitionTests/Validation/CourseOfFireValidationTests.cs
+++ b/tests/BabelFish.Tests/DataModel/DefinitionTests/Validation/CourseOfFireValidationTests.cs
@@ -129,7 +129,7 @@ namespace Scopos.BabelFish.Tests.DataModel.Definition.Validation {
             candidate.PaperTargetLabels[0].ShotsPerBull = 1;
             Assert.IsTrue( await validation.IsSatisfiedByAsync( candidate ), string.Join( " : ", validation.Messages ) );
 
-            //This should fail because a coorsponding Singular doesn't exist with a StageLabel of "S"
+            //This should fail because a corresponding Singular doesn't exist with a StageLabel of "S"
             candidate.PaperTargetLabels[0].Labels.Add( new BarcodeLabel() {
                 StageLabel = "S",
                 Series = new ValueSeries( "1" ),
@@ -137,7 +137,7 @@ namespace Scopos.BabelFish.Tests.DataModel.Definition.Validation {
             } );
             Assert.IsFalse( await validation.IsSatisfiedByAsync( candidate ) );
 
-            // Now shold pass as we have a Singular with a StageLabel of "S"
+            // Now should pass as we have a Singular with a StageLabel of "S"
             candidate.Singulars.Add( new Singular() {
                 StageLabel = "S",
             } );


### PR DESCRIPTION
Downgraded required version of system.text.json as 10.0 was causing downstream issues. Updated specification for BarCodeLabel to allow empty string or one of the values from Singular