### PR TITLE
Task merge from 1.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,34 @@
 # Changelog
 All notable changes to BabelFish will be documented in this file.
 
-
-## [2.1.0-alpha] - 2026-03-00
-** Alpha build, not intended for outside of Scopos use **
-** Contains breaking changes **
+## [2.0] - In Development Now, Expected Summer 2026
+### Breaking Changes
+** Contains many breaking changes **
+- SetNames that were previously represented as strings are now represented as SetName objects.
+- MatchIds that were previously represented as strings are now represented as MatchID objects.
+- Datas and Times that were previously represented as strings are now represented as DateTime objects.
+- The Tournament class is renamed to the ResultListMerger class.
 ### Enhancements
-#### SetName References
-- All SetName references (e.g. TargetDef) have been changed from a string to SetName object.
-- When a SetName in JSON is deserialized, if it can not be parsed or the value is null, the SetName 1.0:orion:Default is returned.
-#### AttributeFilter
-- Added a series of classes, derived from the abstract class AttributeFilter, that specify conditions in which a Participant passes or doesn't pass. Intended to be used to filter a list of Participants for inclusion on a Result List. For example, list all the Participants in a match that are shooting Sporter air rifle.
-- Added the AttributeFilterCalculator that tests if a Participant meets the filter's specifications.
-#### CourseOfFire
-- Added property for RequiredAttributeDef and deprecated DefaultAttributeDef, which will specify which, if any, ATTRIBUTE is required when the COURSE OF FIRE is added to an Orion Match. 
-- Added specification to check that RequiredAttributeDef is a simple attribute, of type string, and each field value specifies an Attribute Value Appelation.
+#### Match
+- Matches may now have multiple Courses of Fire (1.x version allowed only one), each of which is defined in a new class CourseOFFireStructure.
+- Multiple properties within the Match class are now deprecated, as they previously existed when only one Course of Fire was allowed. These deprecated properties will remain for backwards compatibility for at least 1 year after release. They will however point to the first (and default) CourseOfFireStructure.
+- ResultListWizard data actor class is added to generated suggested ResultListAbbr (configuration data for a ResultList) based on a CourseOfFireStructure.
+- AttributeFilterCalculator data actor class is added to filter Participants (both Individuals and Teams) based on their AttributeValues.
+#### MatchProject
+- Added the MatchProject class which is the Top level class that is a container for all data related to an Orion Match (data file). This includes the Match object itself, as well as the Participants, and raw score data. Also includes data actors to help manage the Match data, such as the ShotMapper, ResultDocumentGenerator, ResultListSlidingWindow.
+- MatchProject includes serialization and deserialization methods to save to and read from files.
+- The new ShotMapper data actor stores shot data from ESTs (and other sources) and maps the shots to Events defined by the COURSE OF FIRE.
+- The new ResultDocumentGenerator data actor compiles Participant and Shot data into both (individual) ResultCOF and ResultList instances.
+- The new ResultListSlidingWinow data actor tracks recent versions of ResultList instances to use as comparisons in RankDelta calculations.
+#### RULEBOOK Definition
+- Added the top level RULEBOOK definition. RULEBOOKs contains lists of options for Match Structures, Courses of Fire, and Attributes that a user can use to construct their own Match Structure and Match. 
 
+## [1.12.5] - 2026-05-14
+### Enhancements
+#### ICheckSum
+- Added the ICheckSum interface to calculate a checksum value for high level documents. Intended to check difference in instances between local copy and a server's copy. Implemented in many DataModel/OrionMatch classes including Match, ResultList, ResultCOF, and SquaddingList.
 
-## [1.12.4] - 2026-03-00
+## [1.12.4] - 2026-03-20
 ### Enhancements
 #### GetClubList
 - Added a list of ClubAuthorizationRoles the authenticated caller has for each returned Club.
@@ -29,7 +40,6 @@ All notable changes to BabelFish will be documented in this file.
 #### Authentication
 - Fixed issue with automatically refreshing authentication tokens after 24 hours.
 
-
 ## [1.12.3] - 2026-03-03
 ### Enhancements
 #### ProjectScoresByAverageShotFired
@@ -37,14 +47,12 @@ All notable changes to BabelFish will be documented in this file.
 ### Bug Fixes
 - Fixed issue with TargetAnalysis that was calling an async method in a non-async function.
 
-
 ## [1.12.2] - 2026-02-20
 ### Enhancements
 #### MatchSearchPublicRequest
 - Added ability to search for matches based on the owner of the match (aka Orion Club).
 #### ResultListIntermediateFormattedRow
 - Updated the return value for an Attribute to be the Field's Name (previously was the Field's Value).
-
 
 ### Bug Fixes
 #### MatchAbbr
@@ -67,7 +75,6 @@ All notable changes to BabelFish will be documented in this file.
 - Abstracted the FactoryAsync method to work with either ResultLists or SquaddingList objects.
 - The GenerateExcel method now returns a byte[].
 - When instantiating a new instance, the default behavior is to create an Excel file with two worksheets. The first uses the standard RESULT LIST FORMAT. The second worksheet uses the new dynamically gnerated essential data format RESULT LIST FORMAT.
-
 
 ### Bug Fixes
 #### SquaddingLists

--- a/src/BabelFish/Converters/Newtonsoft.Json/AttributeFilterConverter.cs
+++ b/src/BabelFish/Converters/Newtonsoft.Json/AttributeFilterConverter.cs
@@ -23,7 +23,7 @@ namespace Scopos.BabelFish.Converters.Newtonsoft {
                 case "EQUATION":
                     return JsonConvert.DeserializeObject<AttributeFilterEquation>( jo.ToString(), SpecifiedSubclassConversion );
                 case "NONE":
-                    return AttributeFilter.DEFAULT;
+                    return new AttributeFilterNone();
                 default:
                     //If we get here, it is probable because of ill-formed json
                     return new AttributeFilterAttributeValue();

--- a/src/BabelFish/Converters/System.Text.Json/AttributeFilterConverter.cs
+++ b/src/BabelFish/Converters/System.Text.Json/AttributeFilterConverter.cs
@@ -24,7 +24,7 @@ namespace Scopos.BabelFish.Converters.Microsoft {
                     case "NONE":
                     default:
                         //If we get here, it is probable because of ill-formed json
-                        return AttributeFilter.DEFAULT;
+                        return new AttributeFilterNone();
                 }
             }
         }

--- a/src/BabelFish/DataActors/OrionMatch/CompareOutOfCompetition.cs
+++ b/src/BabelFish/DataActors/OrionMatch/CompareOutOfCompetition.cs
@@ -11,11 +11,16 @@ namespace Scopos.BabelFish.DataActors.OrionMatch {
         public static CompareOutOfCompetition Instance { get; } = new CompareOutOfCompetition();
 
         public int Compare( IEventScores x, IEventScores y ) {
-            if (x.OutOfCompetition == y.OutOfCompetition) {
+            if (x.RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION )
+                == y.RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION )) {
+
                 return x.Participant?.DisplayName.CompareTo( y.Participant?.DisplayName ?? string.Empty ) ?? 0;
-            } else if (x.OutOfCompetition && !y.OutOfCompetition) {
+            } else if (x.RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION )
+                && !y.RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION )) {
+
                 return 1;
             } else {
+
                 return -1;
             }
         }

--- a/src/BabelFish/DataActors/OrionMatch/ResultDocumentGenerator.cs
+++ b/src/BabelFish/DataActors/OrionMatch/ResultDocumentGenerator.cs
@@ -137,7 +137,6 @@ namespace Scopos.BabelFish.DataActors.OrionMatch {
             resultEvent.ResultCOFID = resultCOFID;
             resultEvent.EventScores = await MatchProject.ShotMapper.GetEventScoresAsync( resultCOFID );
             resultEvent.LastShot = MatchProject.ShotMapper.GetLastShot( resultCOFID, true );
-            resultEvent.OutOfCompetition = entry.OutOfCompetition;
 
             // NOTE: Not setting Shots or SquaddingAssignment, as this is not part of a serialized ResultList.
             // NOTE: Do not need to project scores, as GenerateResultListAsync() will do so instead.
@@ -176,7 +175,6 @@ namespace Scopos.BabelFish.DataActors.OrionMatch {
             resultEvent.MatchID = MatchProject.Match.MatchID;
             resultEvent.Participant = await participant.CopyAsync( cofStructure );
             resultEvent.RemarkList = entry.RemarkList;
-            resultEvent.OutOfCompetition = entry.OutOfCompetition;
             resultEvent.TeamMembers = new List<ResultEvent>();
             foreach (var tm in entry.TeamMembers) {
                 CourseOfFireEntry teamMemberEntry;

--- a/src/BabelFish/DataActors/ResultListFormatter/ResultListIntermediateFormattedRow.cs
+++ b/src/BabelFish/DataActors/ResultListFormatter/ResultListIntermediateFormattedRow.cs
@@ -503,7 +503,8 @@ namespace Scopos.BabelFish.DataActors.ResultListFormatter {
 
                     if (_resultEvent is null)
                         return string.Empty;
-                    return _resultEvent.OutOfCompetition ? "OOC" : string.Empty;
+
+                    return _resultEvent.RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION ) ? "OOC" : string.Empty;
 
                 case "Squadding":
                     if (_resultListFormatted.GetParticipantAttributeSquaddingPtr != null)

--- a/src/BabelFish/DataActors/ResultListMerger/AverageMethodConfiguration.cs
+++ b/src/BabelFish/DataActors/ResultListMerger/AverageMethodConfiguration.cs
@@ -24,6 +24,7 @@ namespace Scopos.BabelFish.DataActors.ResultListMerger {
             this.Method = DataModel.OrionMatch.MergeMethodType.AVERAGE;
         }
 
+        #region Data Model Properties
         /// <summary>
         /// If true, an event representing each participants high score will be included.
         /// </summary>
@@ -50,5 +51,15 @@ namespace Scopos.BabelFish.DataActors.ResultListMerger {
         /// </summary>
         [G_NS.JsonProperty( Order = 14, DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Include )]
         public int RequiredNumberOfScores { get; set; } = 1;
+        #endregion
+
+        #region Methods
+
+        public override ulong CalculateChecksum() {
+            var combined = $"{Method}|{AddHighScoreEvent}|{ExcludeDNFFromAverage}|{CountTopScores}|{RequiredNumberOfScores}";
+            return Helpers.Common.Md5ToUlong( combined );
+        }
+
+        #endregion 
     }
 }

--- a/src/BabelFish/DataActors/ResultListMerger/MergeConfiguration.cs
+++ b/src/BabelFish/DataActors/ResultListMerger/MergeConfiguration.cs
@@ -8,8 +8,11 @@ namespace Scopos.BabelFish.DataActors.ResultListMerger {
     /// Abstract class describing the configuration (or properties) that a Merge Method to use while merging result lists.
     /// <para>Most of the properties are concrete class specific.</para>
     /// </summary>
-    public abstract class MergeConfiguration : IGetScoreFormatCollectionDefinition {
+    public abstract class MergeConfiguration :
+        IGetScoreFormatCollectionDefinition,
+        ICheckSum {
 
+        #region Data Model Properties
         /// <summary>
         /// Concrete class identifier. Its value will be the same value as the cooresponding
         /// MergeMethod class' .Method.
@@ -29,6 +32,20 @@ namespace Scopos.BabelFish.DataActors.ResultListMerger {
         [G_NS.JsonProperty( Order = 3 )]
         public string ScoreConfigName { get; set; } = "Decimal";
 
+        #endregion
+
+        #region Helper Properties
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as this is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+        #endregion
+
+        #region Methods
+
         /// <inheritdoc />
         /// <exception cref="XApiKeyNotSetException" />
         /// <exception cref="DefinitionNotFoundException" />
@@ -37,5 +54,10 @@ namespace Scopos.BabelFish.DataActors.ResultListMerger {
 
             return await DefinitionCache.GetScoreFormatCollectionDefinitionAsync( ScoreFormatCollectionDef );
         }
+
+        /// <inheritdoc />
+        public abstract ulong CalculateChecksum();
+
+        #endregion
     }
 }

--- a/src/BabelFish/DataActors/ResultListMerger/ReentryMethodConfiguration.cs
+++ b/src/BabelFish/DataActors/ResultListMerger/ReentryMethodConfiguration.cs
@@ -93,5 +93,14 @@ namespace Scopos.BabelFish.DataActors.ResultListMerger {
 
             return await DefinitionCache.GetResultListFormatDefinitionAsync( ResultListFormatDef );
         }
+
+        #region Methods
+
+        public override ulong CalculateChecksum() {
+            var combined = $"{Method}|{EventType}|{CourseOfFireDef}|{RankingRuleDef}|{ResultListFormatDef}";
+            return Helpers.Common.Md5ToUlong( combined );
+        }
+
+        #endregion 
     }
 }

--- a/src/BabelFish/DataActors/ResultListMerger/SumMethodConfiguration.cs
+++ b/src/BabelFish/DataActors/ResultListMerger/SumMethodConfiguration.cs
@@ -41,5 +41,14 @@ namespace Scopos.BabelFish.DataActors.ResultListMerger {
         /// </summary>
         [G_NS.JsonProperty( Order = 13, DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Include )]
         public int CountTopScores { get; set; } = 0;
+
+        #region Methods
+
+        public override ulong CalculateChecksum() {
+            var combined = $"{Method}|{IncludeHighScoreEvent}|{IncludeAverageScoreEvent}|{CountTopScores}";
+            return Helpers.Common.Md5ToUlong( combined );
+        }
+
+        #endregion 
     }
 }

--- a/src/BabelFish/DataModel/Athena/Penalty.cs
+++ b/src/BabelFish/DataModel/Athena/Penalty.cs
@@ -1,25 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Scopos.BabelFish.DataModel.OrionMatch;
 
-namespace Scopos.BabelFish.DataModel.Athena
-{
-	/// <summary>
-	/// Describes a Penalty that is applied to a shot, athlete, team, etc
-	/// </summary>
+namespace Scopos.BabelFish.DataModel.Athena {
+    /// <summary>
+    /// Describes a Penalty that is applied to a shot, athlete, team, etc
+    /// </summary>
     [Serializable]
-	public class Penalty
-    {
+    public class Penalty : ICheckSum {
 
         private float penalty = 0;
 
         /// <summary>
         /// Public constructor
         /// </summary>
-        public Penalty()
-        {
+        public Penalty() {
         }
 
         /// <summary>
@@ -37,18 +30,13 @@ namespace Scopos.BabelFish.DataModel.Athena
         /// Must be a value greather than or equal to 0.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if attempting to set penalties to a value less than zero.</exception>"
-        public float PenaltyPoints
-        {
+        public float PenaltyPoints {
             get { return penalty; }
-            set
-            {
-                if (value >= 0)
-                {
+            set {
+                if (value >= 0) {
                     penalty = value;
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException($"Penalty points must be greather than or equal to zero. Instead received {value}.");
+                } else {
+                    throw new ArgumentOutOfRangeException( $"Penalty points must be greather than or equal to zero. Instead received {value}." );
                 }
             }
         }
@@ -62,5 +50,20 @@ namespace Scopos.BabelFish.DataModel.Athena
         /// GUID formatted string, the unique ID of the penalty.
         /// </summary>
         public string PenaltyID { get; set; }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; } = string.Empty;
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{RuleNumber}|{Description}|{JuryMember}|{PenaltyID}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+            hash ^= (ulong)(4048 * PenaltyPoints);
+            return hash;
+        }
     }
 }

--- a/src/BabelFish/DataModel/Athena/Score.cs
+++ b/src/BabelFish/DataModel/Athena/Score.cs
@@ -10,7 +10,7 @@ namespace Scopos.BabelFish.DataModel.Athena {
     /// Which property is used to display the score for a given Event is determined by a <see cref="ScoreFormatCollection"/> ScoreFormatDefinition associated with the Event's EventType.
     /// </para>
     /// </summary>
-    public class Score {
+    public class Score : ICheckSum {
 
         #region Private Variables
         private float s = float.NaN;
@@ -130,6 +130,11 @@ namespace Scopos.BabelFish.DataModel.Athena {
         [G_NS.JsonIgnore]
         public int NumShotsFired { get; set; } = 0;
 
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
         #endregion
 
         #region Methods
@@ -184,6 +189,20 @@ namespace Scopos.BabelFish.DataModel.Athena {
             J = 0;
             K = 0;
             L = 0;
+        }
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+
+            ulong hash = (ulong)(16 * this.D);
+            hash = hash << 8 | (uint)this.I;
+            hash = hash << 4 | (uint)this.X;
+            hash = ((ulong)hash << 8) | (uint)(16 * this.S);
+
+            var hash2 = (ulong)(256 * this.J);
+            hash2 = hash2 << 8 | (ulong)(256 * this.K);
+            hash2 = hash2 << 8 | (ulong)(256 * this.L);
+            return hash ^ hash2;
         }
 
         /// <summary>
@@ -266,6 +285,7 @@ namespace Scopos.BabelFish.DataModel.Athena {
         #endregion
 
         #region Operator Overloads
+
         /// <summary>
         /// Operator overload for adding two scores together.
         /// <para>Each score component is added individually.</para>

--- a/src/BabelFish/DataModel/Athena/Shot/Location.cs
+++ b/src/BabelFish/DataModel/Athena/Shot/Location.cs
@@ -1,18 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
+using Scopos.BabelFish.DataModel.OrionMatch;
 
-namespace Scopos.BabelFish.DataModel.Athena.Shot
-{
+namespace Scopos.BabelFish.DataModel.Athena.Shot {
     /// <summary>
     /// Represents the cartisian coordiantes of a shot.
     /// </summary>
 	[Serializable]
-	public class Location
-    {
+    public class Location : ICheckSum {
         /// <summary>
         /// The X cartesian coordinate, measured in mm
         /// </summary>
@@ -37,7 +30,7 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot
         /// </summary>
         /// <returns></returns>
         public double GetRadius() {
-            return Math.Sqrt(GetRadiusSquared());
+            return Math.Sqrt( GetRadiusSquared() );
         }
 
         /// <summary>
@@ -55,8 +48,8 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot
             return (X).ToString( "0.00" );
         }
 
-        public string GetYToString() { 
-            return (Y).ToString( "0.00" ); 
+        public string GetYToString() {
+            return (Y).ToString( "0.00" );
         }
 
         /// <summary>
@@ -65,7 +58,7 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot
         /// <returns></returns>
         public double GetAngle() {
             var xAbs = Math.Abs( X );
-            var yAbs = Math.Abs( Y );   
+            var yAbs = Math.Abs( Y );
 
             //Edge case of very near center of target
             if (xAbs < .0001 && yAbs < .0001)
@@ -80,14 +73,14 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot
                 return (3d * Math.PI / 2.0d);
 
             //Edge case of Y is very near 0 and X is positive
-            if (yAbs < .0001 && X  > 0)
+            if (yAbs < .0001 && X > 0)
                 return 0;
 
             //Edge case of X is very near 0 and X is negative
             if (yAbs < .0001 && X < 0)
                 return Math.PI;
 
-            if (( X > 0 && Y > 0)
+            if ((X > 0 && Y > 0)
                 || (X < 0 && Y > 0))
                 return Math.Atan2( Y, X );
 
@@ -105,6 +98,26 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot
 		public override string ToString() {
             return $"({GetXToString()}, {GetYToString()})";
         }
-	}
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; } = string.Empty;
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var hash = (ulong)(4096 * this.X);
+            if (this.X < 0)
+                hash |= 0x8000000000000000;
+
+            hash = hash << 32 | (uint)(4096 * this.Y);
+            if (this.Y < 0)
+                hash |= 0x8000000000000000;
+
+            return hash;
+        }
+    }
 
 }

--- a/src/BabelFish/DataModel/Athena/Shot/Shot.cs
+++ b/src/BabelFish/DataModel/Athena/Shot/Shot.cs
@@ -8,7 +8,10 @@ using Scopos.BabelFish.DataModel.OrionMatch;
 
 namespace Scopos.BabelFish.DataModel.Athena.Shot {
     [Serializable]
-    public class Shot : IEquatable<Shot>, IPenalty {
+    public class Shot :
+        IEquatable<Shot>,
+        IPenalty,
+        ICheckSum {
 
         float bulletDiameter = 0;
         float scoringDiameter = 0;
@@ -71,7 +74,7 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot {
 
         public Location Location { get; set; }
 
-        [G_STJ_SER.JsonConverter( typeof( Scopos.BabelFish.Converters.Microsoft.ScoposDateTimeConverter ) )]
+        [G_STJ_SER.JsonConverter( typeof( G_BF_STJ_CONV.ScoposDateTimeConverter ) )]
         [G_NS.JsonConverter( typeof( G_BF_NS_CONV.DateTimeConverter ) )]
         public DateTime TimeScored { get; set; }
 
@@ -139,7 +142,7 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot {
             return (ScoringDiameter != BulletDiameter);
         }
 
-        public Scopos.BabelFish.DataModel.Athena.Score Score { get; set; }
+        public Score Score { get; set; }
 
         public string TargetSetName { get; set; }
 
@@ -207,7 +210,8 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot {
         /// <summary>
         /// EventName is only set when the shot is part of a Result COF .Shots dictionary
         /// </summary>
-        public string EventName { get; set; }
+        [DefaultValue( "" )]
+        public string EventName { get; set; } = string.Empty;
 
         /// <summary>
         /// Newtonsoft helper method.
@@ -449,6 +453,33 @@ namespace Scopos.BabelFish.DataModel.Athena.Shot {
                 sum += p.PenaltyPoints;
 
             return sum;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            StringBuilder combined = new StringBuilder( $"{ResultCOFID}|{EventName}|{Update}|{TargetSetName}|{FiringPoint}|{StageLabel}|{Privacy}" );
+
+            if (Attributes is not null && Attributes.Count > 0) {
+                foreach (var a in Attributes)
+                    combined.Append( $"|{a}" );
+            }
+            var hash = Helpers.Common.Md5ToUlong( combined.ToString() );
+
+            hash ^= (ulong)(4048 * Sequence);
+            hash ^= Score.CalculateChecksum();
+            hash ^= Location.CalculateChecksum();
+            foreach (var p in Penalties) {
+                hash ^= p.CalculateChecksum();
+            }
+
+            return hash;
         }
 
         public static async Task<Shot> SimulateAsync( CourseOfFireStructure cofStructure, CourseOfFireEntryIndividual participant, string eventStageName, int sequence ) {

--- a/src/BabelFish/DataModel/AttributeValue/AttributeValue.cs
+++ b/src/BabelFish/DataModel/AttributeValue/AttributeValue.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Scopos.BabelFish.APIClients;
 using Scopos.BabelFish.Converters.Newtonsoft;
 using Scopos.BabelFish.DataModel.Definitions;
+using Scopos.BabelFish.DataModel.OrionMatch;
 
 namespace Scopos.BabelFish.DataModel.AttributeValue {
 
@@ -12,7 +13,7 @@ namespace Scopos.BabelFish.DataModel.AttributeValue {
     /// <para></para>It is generally best to construct a new instance using the <see cref="CreateAsync(SetName)"/> method.</para>
     /// </summary>
     [Serializable]
-    public class AttributeValue : IEquatable<AttributeValue> {
+    public class AttributeValue : ICheckSum, IEquatable<AttributeValue> {
 
         private Logger _logger = LogManager.GetCurrentClassLogger();
 
@@ -569,5 +570,30 @@ namespace Scopos.BabelFish.DataModel.AttributeValue {
             return true;
 
         }
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            StringBuilder combined = new StringBuilder();
+
+            // In order to ensure that the same AttributeValue always has the same CheckSum, we need to order the keys when we combine them into a string for hashing.
+            var topLevelKeys = _attributeValues.Keys.OrderBy( x => x );
+            foreach (var topLevelKey in topLevelKeys) {
+                combined.Append( topLevelKey );
+                var fieldKeys = _attributeValues[topLevelKey].Keys.OrderBy( x => x );
+                foreach (var fieldKey in fieldKeys) {
+                    combined.Append( fieldKey );
+                    combined.Append( _attributeValues[topLevelKey][fieldKey] );
+                }
+            }
+
+            return Helpers.Common.Md5ToUlong( combined.ToString() );
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level object.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; } = string.Empty;
     }
 }

--- a/src/BabelFish/DataModel/AttributeValue/AttributeValueDataPacket.cs
+++ b/src/BabelFish/DataModel/AttributeValue/AttributeValueDataPacket.cs
@@ -1,6 +1,7 @@
 using Scopos.BabelFish.APIClients;
 using Scopos.BabelFish.DataModel.Common;
 using Scopos.BabelFish.DataModel.Definitions;
+using Scopos.BabelFish.DataModel.OrionMatch;
 using Scopos.BabelFish.Responses.AttributeValueAPI;
 
 namespace Scopos.BabelFish.DataModel.AttributeValue {
@@ -10,7 +11,10 @@ namespace Scopos.BabelFish.DataModel.AttributeValue {
     /// <seealso cref="AttributeDef"/> that defines the data, as well as the value <seealso cref="AttributeValue"/>
     /// </summary>
     [G_NS.JsonConverter( typeof( G_BF_NS_CONV.AttributeValueDataPacketConverter ) )]
-    public abstract class AttributeValueDataPacket : IGetAttributeDefinition, IFinishInitializationAsync {
+    public abstract class AttributeValueDataPacket :
+        IGetAttributeDefinition,
+        IFinishInitializationAsync,
+        ICheckSum {
 
         /// <summary>
         /// Default constructor.
@@ -97,5 +101,23 @@ namespace Scopos.BabelFish.DataModel.AttributeValue {
         /// concrete class of this AttributeValueDataPacket, and is set by the overridden ReadJson() method of AttributeValueDataPacketConverter class during deserialization.
         /// </summary>
         public AttributeValueType Type { get; protected set; }
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{AttributeDef}|{Visibility}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            if (AttributeValue is not null) {
+                hash ^= AttributeValue.CalculateChecksum();
+            }
+            return hash;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
     }
 }

--- a/src/BabelFish/DataModel/Definitions/CourseOfFire.cs
+++ b/src/BabelFish/DataModel/Definitions/CourseOfFire.cs
@@ -16,14 +16,19 @@ namespace Scopos.BabelFish.DataModel.Definitions {
     /// </list>
     /// <para>A COURSE OF FIRE should only describe an event that can be completed with one outing to the range. In other words, an athlete should be able to complete the course of fire with one trip to the range. A multi-day event is the combination of two or more COURSE OF FIRE, that is defined outside of this type.</para>
     /// </summary>
-    public class CourseOfFire : Definition, IGetTargetCollectionDefinition, IGetScoreFormatCollectionDefinition, IGetEventAndStageStyleMapping, IGetAttributeDefinition {
+    public class CourseOfFire :
+        Definition,
+        IGetTargetCollectionDefinition,
+        IGetScoreFormatCollectionDefinition,
+        IGetEventAndStageStyleMapping,
+        IGetAttributeDefinition {
 
         /// <summary>
         /// Constructor
         /// </summary>
         public CourseOfFire() : base() {
             Type = DefinitionType.COURSEOFFIRE;
-            PaperTargetLabels = new List<PaperTargetLabel>() { PaperTargetLabel.NONE.Clone() };
+            PaperTargetLabels = new List<PaperTargetLabel>() { PaperTargetLabel.CreateNoneLabel() };
         }
 
         [OnDeserialized]

--- a/src/BabelFish/DataModel/Definitions/PaperTargetLabel.cs
+++ b/src/BabelFish/DataModel/Definitions/PaperTargetLabel.cs
@@ -8,24 +8,25 @@ namespace Scopos.BabelFish.DataModel.Definitions {
     public class PaperTargetLabel : IReconfigurableRulebookObject {
 
         /// <summary>
-        ///  When a <see cref="CourseOfFire"/> RangeScripts are all designed only for ESTs (and not for paper),
-        ///  this default PaperTargetLabel, which does not specify
-        ///  any labels are to be printed, is returned.
-        ///  <para>To use, it is best to Clone() the instance. </para>
-        /// </summary>
-        public readonly static PaperTargetLabel NONE = new PaperTargetLabel() {
-            PaperTargetLabelName = "None",
-            ShotsPerBull = 1,
-            Labels = new List<BarcodeLabel>()
-        };
-
-        /// <summary>
         /// Public constructor
         /// </summary>
         public PaperTargetLabel() {
             PaperTargetLabelName = "";
             Labels = new List<BarcodeLabel>();
             ShotsPerBull = 1;
+        }
+
+        /// <summary>
+        ///  When a <see cref="CourseOfFire"/> RangeScripts are all designed only for ESTs (and not for paper),
+        ///  this method creates a default PaperTargetLabel, which does not specify
+        ///  any labels are to be printed.
+        /// </summary>
+        public static PaperTargetLabel CreateNoneLabel() {
+            return new PaperTargetLabel() {
+                PaperTargetLabelName = "None",
+                ShotsPerBull = 1,
+                Labels = new List<BarcodeLabel>()
+            };
         }
 
         /// <summary>

--- a/src/BabelFish/DataModel/OrionMatch/AttributeFilter.cs
+++ b/src/BabelFish/DataModel/OrionMatch/AttributeFilter.cs
@@ -12,9 +12,9 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     [Serializable]
     [G_STJ_SER.JsonConverter( typeof( G_BF_STJ_CONV.AttributeFilterConverter ) )]
     [G_NS.JsonConverter( typeof( G_BF_NS_CONV.AttributeFilterConverter ) )]
-    public abstract class AttributeFilter : IFinishInitializationAsync {
-
-        public static readonly AttributeFilter DEFAULT = new AttributeFilterNone();
+    public abstract class AttributeFilter :
+        IFinishInitializationAsync,
+        ICheckSum {
 
         /// <summary>
         /// Concret class identifier. 
@@ -45,7 +45,16 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public abstract int Count { get; }
 
         /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as this is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+        /// <inheritdoc />
         public abstract Task FinishInitializationAsync();
+
+        /// <inheritdoc />
+        public abstract ulong CalculateChecksum();
 
     }
 
@@ -78,6 +87,12 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public override async Task FinishInitializationAsync() {
             //Do nothing, since this filter has no attribute values to initialize.
             ;
+        }
+
+        /// <inheritdoc />
+        public override ulong CalculateChecksum() {
+            // Using a random value for the checksum of the default filter, since it has no arguments and thus no properties to calculate a checksum from.
+            return 0x7F3A9C12D4B8E067;
         }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/AttributeFilterAttributeValue.cs
+++ b/src/BabelFish/DataModel/OrionMatch/AttributeFilterAttributeValue.cs
@@ -7,7 +7,11 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// condition where the participant must have (or must not have) specific <seealso cref="AttributeValue.AttributeValue"/> field values.
     /// </summary>
     /// <remarks>To test if a Participant passes the AttributeFilter, use the static <see cref="AttributeFilterCalculator.Passes(AttributeFilter, MatchParticipant)"/> method.</remarks>
-    public class AttributeFilterAttributeValue : AttributeFilter, IEquatable<AttributeFilterAttributeValue>, IEqualityComparer<AttributeFilterAttributeValue>, IFinishInitializationAsync {
+    public class AttributeFilterAttributeValue :
+        AttributeFilter,
+        IEquatable<AttributeFilterAttributeValue>,
+        IEqualityComparer<AttributeFilterAttributeValue>,
+        IFinishInitializationAsync {
 
         /// <summary>
         /// Constructor.
@@ -50,6 +54,18 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <inheritdoc/>
         [G_NS.JsonIgnore]
         public override int Count => 1;
+
+        /// <inheritdoc/>
+        public override ulong CalculateChecksum() {
+            var combined = $"{Operation}|{FilterRule}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            foreach (var val in this.Values) {
+                hash ^= val.CalculateChecksum();
+            }
+
+            return hash;
+        }
 
         /// <summary>
         /// Returns a hash code unique ideifying this AttributeFiler. Incorporating the Operation, Boolean, and </summary>

--- a/src/BabelFish/DataModel/OrionMatch/AttributeFilterEquation.cs
+++ b/src/BabelFish/DataModel/OrionMatch/AttributeFilterEquation.cs
@@ -42,6 +42,19 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <inheritdoc />
         public override int Count => Arguments.Sum( arg => arg.Count );
 
+
+        /// <inheritdoc/>
+        public override ulong CalculateChecksum() {
+            var combined = $"{Operation}|{Boolean}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            foreach (var arg in this.Arguments) {
+                hash ^= arg.CalculateChecksum();
+            }
+
+            return hash;
+        }
+
         /// <inheritdoc/>
         public override string ToString() {
             return string.Join( $" {Boolean} ", Arguments );

--- a/src/BabelFish/DataModel/OrionMatch/CourseOfFireEntry.cs
+++ b/src/BabelFish/DataModel/OrionMatch/CourseOfFireEntry.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-
 namespace Scopos.BabelFish.DataModel.OrionMatch {
 
     /// <summary>
@@ -66,13 +64,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public RemarkList RemarkList { get; set; } = new RemarkList();
 
         /// <summary>
-        /// Gets or sets a boolean indicating whether the Participant is shooting out of competition for this Course of Fire (aka shooting for score only).
-        /// Their scores will be listed, but not ranked. 
-        /// </summary>
-        [DefaultValue( false )]
-        public bool OutOfCompetition { get; set; } = false;
-
-        /// <summary>
         /// This property is considered the source of truth for Team Membership.
         /// <para>A null value means the participant is not currently assigned to any team.</para>
         /// </summary>
@@ -117,6 +108,31 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             }
         }
 
+        /// <summary>
+        /// Helper property that gets or sets a boolean indicating whether the Participant is shooting out of competition for this Course of Fire (aka shooting for score only).
+        /// Their scores will be listed, but not ranked.
+        /// <para>The value is determined by the presence of the OUT_OF_COMPETITION remark in the RemarkList.</para>
+        /// </summary>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public bool OutOfCompetition {
+            get {
+                return RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION );
+            }
+            set {
+                if (!_ignoreEvents) {
+
+                    if (value && !RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION )) {
+                        // If the participant is being marked as out of competition, but does not already have an Out of Competition remark, add one.
+                        RemarkList.AddShowParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION, "Entry marked as OutOfCompetition", 0 );
+
+                    } else if (!value && RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION )) {
+                        // If the participant is being marked as not out of competition, but does have an Out of Competition remark, remove it.
+                        RemarkList.HideParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION );
+                    }
+                }
+            }
+        }
         #endregion
 
         #region Methods

--- a/src/BabelFish/DataModel/OrionMatch/CourseOfFireStructure.cs
+++ b/src/BabelFish/DataModel/OrionMatch/CourseOfFireStructure.cs
@@ -17,7 +17,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         IFinishInitializationAsync,
         IGetCourseOfFireDefinition,
         G_STJ_SER.IJsonOnDeserializing,
-        G_STJ_SER.IJsonOnDeserialized {
+        G_STJ_SER.IJsonOnDeserialized,
+        ICheckSum {
 
         #region Private and Protected Fields
         protected bool _ignoreEvents = false;
@@ -303,6 +304,12 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// </summary>
         [G_NS.JsonIgnore]
         public bool DisableScoreProjection { get; internal set; } = false;
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
         #endregion
 
         #region Methods
@@ -424,7 +431,27 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             }
 
             // Finally return the default NONE, as this COF likely is designed for ESTs, and therefore would not have a PaperTargetLabel value.
-            return PaperTargetLabel.NONE.Clone();
+            return PaperTargetLabel.CreateNoneLabel();
+        }
+
+        /// <inheritdoc />
+        public override string ToString() {
+            return this.CourseOfFireName;
+        }
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{CourseOfFireName}|{CourseOfFireId}|{CourseOfFireDef}|{StartDate.ToString( DateTimeFormats.DATETIME_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATETIME_FORMAT )}|{Official}|{Description}|{ScoreConfigName}|{TargetCollectionName}|{PaperTargetLabelName}|{ProjectorOfScores}|{TypesOfEntries}|{NumberOfTeamMembers}|{MaxNumberOfTeamMembers}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            foreach (var ac in Attributes) {
+                hash ^= ac.CalculateChecksum();
+            }
+
+            foreach (var rl in ResultLists) {
+                hash ^= rl.CalculateChecksum();
+            }
+            return hash;
         }
         #endregion
     }

--- a/src/BabelFish/DataModel/OrionMatch/EventScore.cs
+++ b/src/BabelFish/DataModel/OrionMatch/EventScore.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Scopos.BabelFish.DataActors.ResultListMerger;
 using Scopos.BabelFish.DataModel.Definitions;
 
 
@@ -10,7 +11,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// EventScore format for (JSONVersion) "2022-04-09"
     /// </summary>
     [Serializable]
-    public class EventScore {
+    public class EventScore : ICheckSum {
 
         #region Private Variables
 
@@ -122,20 +123,42 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         #region Helper Properties
 
         /// <summary>
-        /// A Temporary field that's needed by the TournamentMerger
+        /// A Temporary field that's needed by the <see cref="ResultListMergerEngine"/>.
         /// </summary>
         [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
         public MatchID MatchId { get; set; } = MatchID.DEFAULT;
 
         /// <summary>
-        /// A Temporary field that's needed by the TournamentMerger
+        /// A Temporary field that's needed by the <see cref="ResultListMergerEngine"/>.
         /// </summary>
         [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
         public Participant? Participant { get; set; } = null;
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
 
         #endregion
 
         #region Public Methods
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{Status}|{EventType}|{EventName}|{NumShotsFired}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            if (Score is not null)
+                hash ^= Score.CalculateChecksum();
+
+            if (Projected is not null)
+                hash ^= Projected.CalculateChecksum();
+
+            return hash;
+        }
+
         /// <summary>
         /// Returns a string that represents the current object, including the event name and the formatted score.
         /// </summary>
@@ -167,10 +190,10 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// Newtonsoft.json helper method to determine whether the StageStyleDef property should be serialized. We only want to
         /// serialize it if it's not the default value, as otherwise it doesn't add any information and just takes up space in the JSON.
         /// </summary>
-        /// <returns></returns>
         public bool ShouldSerializeStageStyleDef() {
             return !this.StageStyleDef.IsDefault;
         }
+
         #endregion
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/ICheckSum.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ICheckSum.cs
@@ -1,0 +1,32 @@
+namespace Scopos.BabelFish.DataModel.OrionMatch {
+
+    /// <summary>
+    /// Interface to be implemented by classes that need to have a checksum value calculated for them. The checksum value is intended to be a
+    /// unique value that represents the state of the instance's properties, excluding the LastUpdated and CheckSum properties. The CalculateChecksum()
+    /// method should return the same value across multiple serializations and deserializations of the same instance, assuming the underlying data did not change.
+    /// This allows for integrity verification after deserialization and comparison between server and local copies of the instance.
+    /// </summary>
+    public interface ICheckSum {
+
+        /// <summary>
+        /// A hashed value that is unique to this instance. The value is calculated by the CalculateChecksum() method.
+        /// </summary>
+        /// <remarks>To maintain backward compatibility, CheckSum is a string representation of the hash value (and not an ulong) and
+        /// spelled with a capital S in CheckSum.</remarks>
+        /// <remarks>Class instances that are not, by them selves, stored on the server may mark this property as JsonIgnore.</remarks>
+        public string CheckSum { get; set; }
+
+        /// <summary>
+        /// Calculates a checksum value that represents the current state of the instance's properties, excluding the
+        /// LastUpdated and CheckSum properties. Assuming the underlying data did not change, the value of this method should be the same
+        /// across multiple serializations and deserializations of the same instance.
+        /// <para>The intent of this method is two-fold. First to provide a way to verify the integrity of the instance's data after deserialization.
+        /// If someone (or something) modified the serialized values then CalculateChecksum should return a different value. While we may not know
+        /// what changed, we can at least detect something manipulated the data.</para>
+        /// <para>The second intent is to compare the value of the instance on the server to the local copy. If the value is the same (on the
+        /// server and locally) then the server has the up to date instance value.</para>
+        /// </summary>
+        /// <returns>A ulong containing the calculated checksum value for the instance.</returns>
+        public ulong CalculateChecksum();
+    }
+}

--- a/src/BabelFish/DataModel/OrionMatch/IEventScores.cs
+++ b/src/BabelFish/DataModel/OrionMatch/IEventScores.cs
@@ -45,13 +45,17 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <summary>
         /// The UTC time this IEventScore was last updated.
         /// </summary>
-        public DateTime LastUpdated { get; set; }
+        DateTime LastUpdated { get; set; }
 
         /// <summary>
-        /// Boolean indicating if this Participant is shooting out of competition for this Event (aka shooting for score only).
-        /// If true, their scores will be listed, but not ranked.
+        /// Gets or sets the collection of <see cref="RemarkAction"/> associated with the current entity.
         /// </summary>
-        bool OutOfCompetition { get; set; }
+        RemarkList RemarkList { get; set; }
+
+        /// <summary>
+        /// Helper property returning true if the RemarkList is showing the ParticipantRemark.OUT_OF_COMPETITION remark, which indicates that the participant is shooting out of competition (for score only).
+        /// </summary>
+        bool OutOfCompetition { get; }
 
         /// <summary>
         /// Returns the Status of the top level Event (Event Type Event).

--- a/src/BabelFish/DataModel/OrionMatch/Individual.cs
+++ b/src/BabelFish/DataModel/OrionMatch/Individual.cs
@@ -168,5 +168,20 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
                     return this.DisplayName.ToUpper().Trim().GetHashCode();
             }
         }
+
+
+        /// <inheritdoc />
+        public override ulong CalculateChecksum() {
+            var combined = $"{DisplayName}|{GivenName}|{MiddleName}|{FamilyName}|{CompetitorNumber}|{Country}|{HomeTown}|{Club}|{TeamName}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            foreach (var attributeValue in AttributeValues) {
+                hash ^= attributeValue.CalculateChecksum();
+            }
+
+            hash ^= RemarkList.CalculateChecksum();
+
+            return hash;
+        }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/Match.cs
+++ b/src/BabelFish/DataModel/OrionMatch/Match.cs
@@ -18,6 +18,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         IFinishInitializationAsync,
         G_STJ_SER.IJsonOnDeserialized,
         G_STJ_SER.IJsonOnDeserializing,
+        ICheckSum,
         IEquatable<Match> {
 
         #region Private and Protected Fields
@@ -482,7 +483,21 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         #endregion
 
+        #region Helper Properties
+        /// <inheritdoc />
+        public string CheckSum { get; set; }
+
+        #endregion
+
         #region Methods
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{Name}|{MatchID}|{OwnerId}|{CourseOfFireDef}|{ScoreConfigName}|{TargetCollectionName}|{Location}|{MatchType}|{StartDate.ToString( DateTimeFormats.DATE_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATE_FORMAT )}|{Visibility}|{JSONVersion}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            return hash;
+        }
 
         /// <inheritdoc />
         public override string ToString() {
@@ -612,7 +627,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
             return json;
         }
-
         #endregion
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/Match.cs
+++ b/src/BabelFish/DataModel/OrionMatch/Match.cs
@@ -18,6 +18,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         IFinishInitializationAsync,
         G_STJ_SER.IJsonOnDeserialized,
         G_STJ_SER.IJsonOnDeserializing,
+        G_STJ_SER.IJsonOnSerializing,
         ICheckSum,
         IEquatable<Match> {
 
@@ -73,14 +74,25 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
             _ignoreEvents = false;
             this.MatchStructure.Match = this;
+
+            if (this.CheckSum != CalculateChecksum().ToString()) {
+                _logger.Error( $"Checksum mismatch for Match {MatchID}. Calculated Checksum: {CalculateChecksum()}, Checksum in data: {this.CheckSum}. This may indicate that the data was modified after it was last saved, or that there was an error during serialization or deserialization." );
+            }
         }
 
         /// <summary>
         /// Method is called before deserialization with System.Text.Json.
         /// </summary>
         public void OnDeserializing() {
-
             _ignoreEvents = true;
+        }
+
+        /// <summary>
+        /// Method is called before serialization with System.Text.Json.
+        /// </summary>
+        public void OnSerializing() {
+            // Calculate and set the checksum before serialization, so that the checksum is included in the serialized data and can be used to verify data integrity when deserializing.
+            this.CheckSum = CalculateChecksum().ToString();
         }
 
         /// <summary>
@@ -264,13 +276,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_NS.JsonProperty( Order = 21 )]
         public List<Contact> MatchContacts { get; set; } = new List<Contact>();
 
-
-        #region BabelFish 2.0 / Orion 3.0 DataModel
-        /*
-         * The properties in this region are new with the release of BabelFish 2.0 and Orion version 3.0, 
-         * and are not populated in older versions of the software. They are largely related to the new 
-         * feature of supporting multiple Courses of Fire within a Match, and the new Match Structure that supports that feature. 
-         */
         /// <summary>
         /// 
         /// </summary>
@@ -278,56 +283,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_STJ_SER.JsonPropertyOrder( 30 )]
         [G_NS.JsonProperty( Order = 30 )]
         public MatchStructure MatchStructure { get; set; }
-        #endregion
-
-        /// <summary>
-        /// The names of the scoring system used to score shots within this match. For example, "Orion Scoring System."
-        /// </summary>
-        [G_STJ_SER.JsonPropertyOrder( 40 )]
-        [G_NS.JsonProperty( Order = 40 )]
-        public List<string> ScoringSystems { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Newtonsoft.json helper method, to determine if ScoreSystems property should be serialized.
-        /// </summary>
-        /// <returns></returns>
-        public bool ShouldSerializeScoringSystems() {
-            return ScoringSystems != null && ScoringSystems.Count > 0;
-        }
-
-        /// <summary>
-        /// The type of scoring system used in this match, such as PAPER_TARGER or EST.
-        /// </summary>
-        [G_STJ_SER.JsonPropertyOrder( 41 )]
-        [G_NS.JsonProperty( Order = 41 )]
-        [DefaultValue( ScoringSystem.UNKNOWN )]
-        public ScoringSystem ScoringSystemType { get; set; } = ScoringSystem.UNKNOWN;
-
-        #region Move To Seperate Objects
-        /*
-         * The properties in this region are important as part of the REST API return Get Match Detail(),
-         * however they do not belong as part of the Match object itsefl. Think they should be moved to a 
-         * new object that is returned as part of the Get Match Detail() API call.
-         */
-
-        /// <summary>
-        /// A list of authorized capabilities the caller has for this match. These values are 
-        /// returned by the Rest API, but are not serialized. Instead 'AuthorizationList'
-        /// is sent, and the list of Authorizations is derved using it and the caller's identificaiton.
-        /// </summary>
-        [G_STJ_SER.JsonPropertyOrder( 51 )]
-        [G_NS.JsonProperty( Order = 51 )]
-        [Obsolete( "Will be replaced with the Permissions list, which is returned in parrallel to GetMatchDetail API call. Deprecated March 2026." )]
-        public List<MatchAuthorizationCapability> Authorization { get; set; } = new List<MatchAuthorizationCapability>();
-
-        /// <summary>
-        /// NewtonSoft helper method to determine if Authoirazation should be serialized.
-        /// </summary>
-        /// <returns></returns>
-        public bool ShouldSerializeAuthorization() {
-            return Authorization is not null && Authorization.Count > 0;
-        }
-        #endregion
 
         /// <summary>
         /// The orion account or at home account who owns this match.
@@ -358,6 +313,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_NS.JsonProperty( Order = 99 )]
         public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 
+        #region Deprecated Properties for Backwards Compatibility with Older Versions of the API
         /*
          * The properties in this region are deprecated, and should not be used anymore. They are only kept here for backward compatibility with older versions of the API, and to avoid breaking changes. They will eventually be removed in a future version, but for now they are marked as Obsolete.
          */
@@ -445,21 +401,63 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             "Deprecated December 2025." )]
         public string SharedKey { get; set; } = String.Empty;
 
-        /*
-         * EKA Note November 2025
-         * Removed as a property, because Role Authorization is saved instead to the MatchParticipant object. No need to replicate that data here.
-         *
         /// <summary>
-        /// A list of Authorization roles participants in the match have.
-        /// This list is sent to the Cloud, but is never seen as part of the Rest API. Instead
-        /// the Rest API sends back a list of Authorizations the caller has in the match, with 
-        /// the Property 'Authorization'.
-        ///
-        /// This list is only ever uploaded to the cloud. It is never (or at least should never) be
-        /// sent back as part of an API request. 
-        /// </summary>G_STJ_SER.G_STJ_SER.JsonPropertyOrder
-        public List<MatchAuthorization> AuthorizationList { get; set; } = new List<MatchAuthorization>();
-        */
+        /// The names of the scoring system used to score shots within this match. For example, "Orion Scoring System."
+        /// </summary>
+        [G_STJ_SER.JsonPropertyOrder( 40 )]
+        [G_NS.JsonProperty( Order = 40 )]
+        [Obsolete( "Replaced with CourseOfFireStructure.MetaData.ScoringTechnology, as each Course of Fire can have its own scoring system. Deprecated May 2026." )]
+        public List<string> ScoringSystems { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Newtonsoft.json helper method, to determine if ScoreSystems property should be serialized.
+        /// </summary>
+        /// <returns></returns>
+        public bool ShouldSerializeScoringSystems() {
+            return ScoringSystems != null && ScoringSystems.Count > 0;
+        }
+
+        /// <summary>
+        /// The type of scoring system used in this match, such as PAPER_TARGER or EST.
+        /// </summary>
+        [G_STJ_SER.JsonPropertyOrder( 41 )]
+        [G_NS.JsonProperty( Order = 41 )]
+        [DefaultValue( ScoringSystem.UNKNOWN )]
+        [Obsolete( "Replaced with CourseOfFireStructure.MetaData.ScoringTechnology, as each Course of Fire can have its own scoring system. Deprecated May 2026." )]
+        public ScoringSystem ScoringSystemType { get; set; } = ScoringSystem.UNKNOWN;
+
+        #endregion
+
+
+        #region Move To Seperate Objects
+        /*
+         * The properties in this region are important as part of the REST API return Get Match Detail(),
+         * however they do not belong as part of the Match object itsefl. Think they should be moved to a 
+         * new object that is returned as part of the Get Match Detail() API call.
+         */
+
+        /// <summary>
+        /// A list of authorized capabilities the caller has for this match. These values are 
+        /// returned by the Rest API, but are not serialized. Instead 'AuthorizationList'
+        /// is sent, and the list of Authorizations is derved using it and the caller's identificaiton.
+        /// </summary>
+        [G_STJ_SER.JsonPropertyOrder( 51 )]
+        [G_NS.JsonProperty( Order = 51 )]
+        [Obsolete( "Will be replaced with the Permissions list, which is returned in parrallel to GetMatchDetail API call. Deprecated March 2026." )]
+        public List<MatchAuthorizationCapability> Authorization { get; set; } = new List<MatchAuthorizationCapability>();
+
+        /// <summary>
+        /// NewtonSoft helper method to determine if Authoirazation should be serialized.
+        /// </summary>
+        /// <returns></returns>
+        public bool ShouldSerializeAuthorization() {
+            return Authorization is not null && Authorization.Count > 0;
+        }
+        #endregion
+
+        #endregion
+
+        #region Helper Properties
 
         /// <summary>
         /// Helper function that indicates if this Match is currently going on. Which is 
@@ -481,9 +479,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_NS.JsonIgnore]
         public MatchProject? MatchProject { get; internal set; }
 
-        #endregion
-
-        #region Helper Properties
         /// <inheritdoc />
         public string CheckSum { get; set; }
 
@@ -493,8 +488,10 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         /// <inheritdoc />
         public ulong CalculateChecksum() {
-            var combined = $"{Name}|{MatchID}|{OwnerId}|{CourseOfFireDef}|{ScoreConfigName}|{TargetCollectionName}|{Location}|{MatchType}|{StartDate.ToString( DateTimeFormats.DATE_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATE_FORMAT )}|{Visibility}|{JSONVersion}";
+            var combined = $"{Name}|{MatchID}|{OwnerId}|{Location}|{MatchType}|{StartDate.ToString( DateTimeFormats.DATE_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATE_FORMAT )}|{MemberPolicy}|{Visibility}|{JSONVersion}";
             var hash = Helpers.Common.Md5ToUlong( combined );
+
+            hash ^= MatchStructure.CalculateChecksum();
 
             return hash;
         }

--- a/src/BabelFish/DataModel/OrionMatch/MatchEnums.cs
+++ b/src/BabelFish/DataModel/OrionMatch/MatchEnums.cs
@@ -650,7 +650,12 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <summary>
         /// Three dots (...) show when we don't want to show un-updated information.
         /// </summary>
-        ELLIPSES
+        ELLIPSES,
+
+        /// <summary>
+        /// Out of competition. Used when a Participant is competing for score only.
+        /// </summary>
+        OUT_OF_COMPETITION
     };
 
     /// <summary>

--- a/src/BabelFish/DataModel/OrionMatch/MatchParticipant.cs
+++ b/src/BabelFish/DataModel/OrionMatch/MatchParticipant.cs
@@ -13,7 +13,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         ISaveToFile,
         IFinishInitializationAsync,
         G_STJ_SER.IJsonOnDeserializing,
-        G_STJ_SER.IJsonOnDeserialized {
+        G_STJ_SER.IJsonOnDeserialized,
+        ICheckSum {
 
         /// <summary>
         /// The Folder name, with respect to the MatchProject's root directory, that MatchParticipant instances are stored in.
@@ -113,6 +114,10 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_NS.JsonProperty( Order = 3 )]
         public string ParticipantID { get; set; } = Scopos.BabelFish.Helpers.Common.GenerateUniqueId();
 
+        [G_STJ_SER.JsonConverter( typeof( G_BF_STJ_CONV.ScoposDateOnlyConverter ) )]
+        [G_NS.JsonConverter( typeof( G_BF_NS_CONV.DateConverter ) )]
+        public DateTime LocalDate { get; set; }
+
         /// <summary>
         /// UUID formatted Scopos Account user id.
         /// <para>If missing or an empty string, likely means this Participant is either a Team, or is an Individual but does not have a Scopos Account.</para>
@@ -180,6 +185,9 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// </summary>
         [G_NS.JsonIgnore]
         public MatchProject? Project { get; internal set; } = null;
+
+        /// <inheritdoc />
+        public string CheckSum { get; set; }
         #endregion
 
         #region Methods
@@ -248,6 +256,18 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             } else {
                 return CreateEntry( courseOfFireId );
             }
+        }
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{MatchID}|{MatchName}|{ParticipantID}|{UserID}|{LocalDate.ToString( DateTimeFormats.DATE_FORMAT )}|{Creator}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            if (Participant is not null) {
+                hash ^= Participant.CalculateChecksum();
+            }
+
+            return hash;
         }
 
         /// <inheritdoc/>
@@ -355,4 +375,5 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         #endregion
     }
+
 }

--- a/src/BabelFish/DataModel/OrionMatch/MatchProject.cs
+++ b/src/BabelFish/DataModel/OrionMatch/MatchProject.cs
@@ -5,6 +5,12 @@ using Scopos.BabelFish.DataModel.Clubs;
 using Scopos.BabelFish.DataModel.Common;
 
 namespace Scopos.BabelFish.DataModel.OrionMatch {
+
+    /// <summary>
+    /// Top level class that is a container for all data related to an Orion Match (data file). This includes the Match object itself, as well as the Participants, raw score data and more.
+    /// Also includes data actors to help manage the <see cref="Match"/> data, such as the <see cref="ShotMapper"/>, <see cref="ResultDocumentGenerator"/>,
+    /// and <see cref="ResultListSlidingWindow"/>.
+    /// </summary>
     public class MatchProject :
         ISaveToFile,
         IResultListFetcher,

--- a/src/BabelFish/DataModel/OrionMatch/MatchStructure.cs
+++ b/src/BabelFish/DataModel/OrionMatch/MatchStructure.cs
@@ -15,7 +15,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         IMergedResultListContainer,
         IFinishInitializationAsync,
         G_STJ_SER.IJsonOnDeserializing,
-        G_STJ_SER.IJsonOnDeserialized {
+        G_STJ_SER.IJsonOnDeserialized,
+        ICheckSum {
 
         #region Private and Protected Fields
         protected bool _ignoreEvents = false;
@@ -140,6 +141,13 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
                 return Match?.MatchProject ?? null;
             }
         }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as this is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
         #endregion
 
         #region Methods
@@ -248,6 +256,24 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             return mrl;
         }
 
+        /// <inheritdoc/>
+        public ulong CalculateChecksum() {
+            ulong hash = 0;
+
+            foreach (var cof in CoursesOfFire) {
+                hash ^= cof.CalculateChecksum();
+            }
+
+            foreach (var globalAttribute in GlobalAttributes) {
+                hash ^= globalAttribute.CalculateChecksum();
+            }
+
+            foreach (var mrl in MergedResultLists) {
+                hash ^= mrl.CalculateChecksum();
+            }
+
+            return hash;
+        }
         #endregion
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/MergedResultList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/MergedResultList.cs
@@ -11,7 +11,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     public class MergedResultList :
         IGetScoreFormatCollectionDefinition,
         G_STJ_SER.IJsonOnDeserialized,
-        G_STJ_SER.IJsonOnDeserializing {
+        G_STJ_SER.IJsonOnDeserializing,
+        ICheckSum {
 
         #region Private Variables
         private bool _ignoreEvents = false;
@@ -129,6 +130,12 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// </summary>
         [G_NS.JsonIgnore]
         public IMergedResultListContainer Container { get; internal set; }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as this is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
         #endregion
 
         #region Methods
@@ -164,6 +171,19 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <exception cref="ScoposAPIException" />
         public async Task<ScoreFormatCollection> GetScoreFormatCollectionDefinitionAsync() {
             return await DefinitionCache.GetScoreFormatCollectionDefinitionAsync( this.Configuration.ScoreFormatCollectionDef );
+        }
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{ResultName}|{MergedId}|{Method}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            hash ^= Configuration.CalculateChecksum();
+
+            foreach (var member in ResultListMembers) {
+                hash ^= member.CalculateChecksum();
+            }
+            return hash;
         }
 
         #endregion

--- a/src/BabelFish/DataModel/OrionMatch/Participant.cs
+++ b/src/BabelFish/DataModel/OrionMatch/Participant.cs
@@ -13,7 +13,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     [G_NS.JsonConverter( typeof( G_BF_NS_CONV.ParticipantConverter ) )]
     public abstract class Participant :
         G_STJ_SER.IJsonOnDeserializing,
-        G_STJ_SER.IJsonOnDeserialized {
+        G_STJ_SER.IJsonOnDeserialized,
+        ICheckSum {
 
         /// <summary>
         /// The expected maximum length of the DisplayNameShort property. This is not a hard limit, but by convention DisplayNameShorts should be 20 characters or less. DisplayName may be any length.
@@ -438,5 +439,15 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_STJ_SER.JsonIgnore]
         [G_NS.JsonIgnore]
         public abstract int UniqueMergeId { get; }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+
+        /// <inheritdoc />
+        public abstract ulong CalculateChecksum();
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/RemarkAction.cs
+++ b/src/BabelFish/DataModel/OrionMatch/RemarkAction.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Amazon.Auth.AccessControlPolicy;
-
 namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// <summary>
     /// Object that holds the RemarkName and Reason for a remark, if needed.
     /// This is mostly notation on the participants status within a match.
     /// </summary>
     [Serializable]
-    public class RemarkAction {
+    public class RemarkAction : ICheckSum {
         /// <summary>
         /// this would be the name of the remark being given, DNS, DSQ, Eliminated, etc.
         /// </summary>
@@ -30,7 +25,9 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_NS.JsonProperty( Order = 3 )]
         public string Reason { get; set; } = string.Empty;
 
-
+        /// <summary>
+        /// The UTC time that this remark was applied.
+        /// </summary>
         [G_STJ_SER.JsonConverter( typeof( G_BF_STJ_CONV.ScoposDateTimeConverter ) )]
         [G_NS.JsonConverter( typeof( G_BF_NS_CONV.DateTimeConverter ) )]
         [G_NS.JsonProperty( Order = 4 )]
@@ -46,6 +43,20 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <inheritdoc />
         public override string ToString() {
             return $"{ParticipantRemark.Description()} {Visibility.Description()}";
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; } = string.Empty;
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{ParticipantRemark}|{Visibility}|{Reason}|{AppliedAt.ToString( Helpers.DateTimeFormats.DATETIME_FORMAT )}|{ActionId}";
+
+            return Helpers.Common.Md5ToUlong( combined );
         }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/RemarkAction.cs
+++ b/src/BabelFish/DataModel/OrionMatch/RemarkAction.cs
@@ -1,3 +1,5 @@
+using Scopos.BabelFish.DataModel.Definitions;
+
 namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// <summary>
     /// Object that holds the RemarkName and Reason for a remark, if needed.
@@ -35,7 +37,10 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         /// <summary>
         /// RemarkActions that are added through CommandAutomationRemark must have a unique identifier 
-        /// (to identify what automation added it). 
+        /// (to identify what automation added it) which is called ActionId.
+        /// <para>During the conduct of a <see cref="RangeScript"/> some <see cref="SegmentGroupCommand"/> may apply
+        /// multiple RemarkActions to multiple Participants. If the RangeCommand needs to be reversed (
+        /// for example the RangeOfficer hit NextCommand too soon) then all RemarkActions with the same ActionId can be identified and reversed.</para>
         /// </summary>
         [G_NS.JsonProperty( Order = 5 )]
         public int ActionId { get; set; } = 0;
@@ -54,7 +59,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         /// <inheritdoc />
         public ulong CalculateChecksum() {
-            var combined = $"{ParticipantRemark}|{Visibility}|{Reason}|{AppliedAt.ToString( Helpers.DateTimeFormats.DATETIME_FORMAT )}|{ActionId}";
+            var combined = $"{ParticipantRemark}|{Visibility}|{Reason}|{AppliedAt.ToString( DateTimeFormats.DATETIME_FORMAT )}|{ActionId}";
 
             return Helpers.Common.Md5ToUlong( combined );
         }

--- a/src/BabelFish/DataModel/OrionMatch/RemarkAction.cs
+++ b/src/BabelFish/DataModel/OrionMatch/RemarkAction.cs
@@ -59,7 +59,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         /// <inheritdoc />
         public ulong CalculateChecksum() {
-            var combined = $"{ParticipantRemark}|{Visibility}|{Reason}|{AppliedAt.ToString( DateTimeFormats.DATETIME_FORMAT )}|{ActionId}";
+            // Note that we are not including AppliedAt in the checksum because it doesn't seem to be persisting correctly, so when Orion opens the document it always sets to UTC NOW. Which his different on each open.
+            var combined = $"{ParticipantRemark}|{Visibility}|{Reason}|{ActionId}";
 
             return Helpers.Common.Md5ToUlong( combined );
         }

--- a/src/BabelFish/DataModel/OrionMatch/RemarkList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/RemarkList.cs
@@ -7,7 +7,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// <para>Generally the best way to test if a RemarkList includes a specific <see cref="RemarkAction"/> is to use the IsShowingParticipantRemark() method.</para>
     /// </summary>
     [Serializable]
-    public class RemarkList : List<RemarkAction> {
+    public class RemarkList : List<RemarkAction>, ICheckSum {
         //public List<Remark> remarks = new List<Remark>();
 
         public readonly List<ParticipantRemark> PriorityOfRemarks = new List<ParticipantRemark>() {
@@ -267,6 +267,23 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
                 }
 
             return "";
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; } = string.Empty;
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            ulong hash = 0;
+            foreach (var action in this) {
+                hash ^= action.CalculateChecksum();
+            }
+
+            return hash;
         }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/RemarkList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/RemarkList.cs
@@ -214,6 +214,13 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
                 return "DNF";
             if (this.IsShowingParticipantRemark( ParticipantRemark.DNS ))
                 return "DNS";
+            if (this.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION )) {
+                if (!useAbbreviations) {
+                    return "Guest";
+                } else {
+                    return "OOC";
+                }
+            }
             if (this.IsShowingParticipantRemark( ParticipantRemark.FIRST ))
                 if (!useAbbreviations) {
                     return "FIRST";

--- a/src/BabelFish/DataModel/OrionMatch/RemarkList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/RemarkList.cs
@@ -14,10 +14,12 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
                     ParticipantRemark.DSQ,
                     ParticipantRemark.DNS,
                     ParticipantRemark.DNF,
+                    ParticipantRemark.OUT_OF_COMPETITION,
                     ParticipantRemark.FIRST,
                     ParticipantRemark.SECOND,
                     ParticipantRemark.THIRD,
                     ParticipantRemark.ELIMINATED,
+                    ParticipantRemark.QUALIFIED,
                     ParticipantRemark.ELLIPSES,
                     ParticipantRemark.BUBBLE,
                     ParticipantRemark.LEADER};
@@ -37,8 +39,11 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// If this RemarkList is already shwoing a ParticipantRemark of type remark,
         /// then two Remarks are added, one SHOW and one HIDE (which keeps the balance of showing 1 or 0).
         /// </summary>
-        /// <param name="remark"></param>
-        /// <param name="reason"></param>
+        /// <param name="remark">The <see cref="ParticipantRemark"/> to add.</param>
+        /// <param name="reason">The reason for adding the remark.</param>
+        /// <param name="actionId">The action ID (also called an automation id) associated with the remark. When RemarkAction is
+        /// added via a <see cref="CommandAutomationRemark"/>, this ID is used to track the automation that added it. May typically
+        /// be 0 otherwise.</param>
 		public void AddShowParticipantRemark( ParticipantRemark remark, string reason = "", int actionId = 0 ) {
             bool hasRemarkAlready = this.IsShowingParticipantRemark( remark );
 
@@ -67,7 +72,11 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// is added to hide it. If the RemarkList is not showing a ParticpantRemark of type remark,
         /// then no RemarkAction is added.
         /// </summary>
-        /// <param name="remark"></param>
+        /// <param name="remark">The <see cref="ParticipantRemark"/> to hide.</param>
+        /// <param name="reason">The reason for adding the remark.</param>
+        /// <param name="actionId">The action ID (also called an automation id) associated with the remark. When RemarkAction is
+        /// added via a <see cref="CommandAutomationRemark"/>, this ID is used to track the automation that added it. May typically
+        /// be 0 otherwise.</param>
         public void HideParticipantRemark( ParticipantRemark remark, string reason = "", int actionId = 0 ) {
             if (this.IsShowingParticipantRemark( remark )) {
                 var remarkAction = new RemarkAction() {
@@ -82,13 +91,13 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         /// <summary>
         /// Removes all RemarkAction items in this RemarkList that have a
-        /// command automation id equal to the passed in automationId.
+        /// command ActionId equal to the passed in value.
         /// </summary>
-        /// <param name="automationId"></param>
-        public void RemoveAutomationRemark( int automationId ) {
+        /// <param name="actionId"></param>
+        public void RemoveAutomationRemark( int actionId ) {
             List<RemarkAction> remarksToRemove = new List<RemarkAction>();
             foreach (var ra in this) {
-                if (ra.ActionId == automationId) {
+                if (ra.ActionId == actionId) {
                     remarksToRemove.Add( ra );
                 }
             }

--- a/src/BabelFish/DataModel/OrionMatch/ResultCOF.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultCOF.cs
@@ -11,7 +11,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     [Serializable]
     public class ResultCOF :
         IEventScoreProjection,
-        ISaveToFile {
+        ISaveToFile,
+        ICheckSum {
 
         #region Private Variables
         //Key is the Singular Event Name, Value is the Shot
@@ -477,6 +478,37 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         #endregion
 
         #endregion
+
+        /// <inheritdoc />
+        public string CheckSum { get; set; }
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{ResultCOFID}|{OwnerId}|{Status}|{Visibility}|{MatchID}|{MatchName}|{MatchLocation}|{ParentID}|{MatchType}|{LocalDate.ToString( DateTimeFormats.DATE_FORMAT )}|{FiringPointNumber}|{Creator}|{CourseOfFireDef}|{ScoreConfigName}|{TargetCollectionName}|{DefaultTargetDefinition}|{UserID}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            hash ^= Participant.CalculateChecksum();
+
+            if (EventScores is not null) {
+                foreach (var es in EventScores) {
+                    hash ^= es.Value.CalculateChecksum();
+                }
+            }
+
+            if (Shots is not null) {
+                foreach (var es in Shots) {
+                    hash ^= es.Value.CalculateChecksum();
+                }
+            }
+
+            if (ResultCofScores is not null) {
+                foreach (var rCof in ResultCofScores) {
+                    hash ^= rCof.Value.CalculateChecksum();
+                }
+            }
+
+            return hash;
+        }
 
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/ResultEvent.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultEvent.cs
@@ -7,7 +7,10 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// A ResultEvent represents the score one participant earned in an Event. ResultEvents often contain the score
     /// not just for the top level Event, but for the children as well.
     /// </summary>
-    public class ResultEvent : IEventScoreProjection, IRLIFItem {
+    public class ResultEvent :
+        IEventScoreProjection,
+        IRLIFItem,
+        ICheckSum {
 
         //Key is the Singular Event Name, Value is the Shot
         private Dictionary<string, Athena.Shot.Shot> shotsByEventName = null;
@@ -284,6 +287,12 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         }
 
         /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; } = string.Empty;
+
+        /// <inheritdoc />
         public bool CurrentlyCompetingOrRecentlyDone() {
             if (GetStatus() == ResultStatus.INTERMEDIATE)
                 return true;
@@ -297,6 +306,37 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <inheritdoc />
         public override string ToString() {
             return $"ResultEvent for {this.Participant.DisplayName}";
+        }
+
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combine = $"{MatchID}|{Rank}|{RankOrder}|{RankDelta}|{ProjectedRank}|{ProjectedRankOrder}|{LocalDate.ToString( DateTimeFormats.DATE_FORMAT )}";
+            var hash = Helpers.Common.Md5ToUlong( combine );
+
+            hash ^= Participant.CalculateChecksum();
+
+            if (EventScores is not null) {
+                foreach (var es in EventScores) {
+                    hash ^= es.Value.CalculateChecksum();
+                }
+            }
+
+            if (ResultCofScores is not null) {
+                foreach (var rCof in ResultCofScores) {
+                    hash ^= rCof.Value.CalculateChecksum();
+                }
+            }
+
+            if (TeamMembers is not null) {
+                foreach (var tm in TeamMembers) {
+                    hash ^= tm.CalculateChecksum();
+                }
+            }
+
+            // NOTE: We are purposefully not including Shots in the checksum calculation, as this property is not included in the REST API response for ResultEvents.
+
+            return hash;
         }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/ResultEvent.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultEvent.cs
@@ -12,14 +12,22 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         IRLIFItem,
         ICheckSum {
 
+        #region Private Fields
         //Key is the Singular Event Name, Value is the Shot
-        private Dictionary<string, Athena.Shot.Shot> shotsByEventName = null;
+        private Dictionary<string, Athena.Shot.Shot> _shotsByEventName = null;
 
+        //Cached copy of the name of the top level event.
+        private string _topLevelEventName = "";
+        #endregion
+
+        #region Constructors, Factory Methods, and Initialization
         public ResultEvent() {
             //Purposefully set TeamMemebers to null so if it is an individual the attribute doesn't get added into the JSON
             TeamMembers = null;
         }
+        #endregion
 
+        #region Data Model Properties
         /// <summary>
         /// Data on the person or team who shot this score.
         /// </summary>
@@ -100,41 +108,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_NS.JsonProperty( Order = 9 )]
         public DateTime LocalDate { get; set; } = DateTime.Today;
 
-        /// <inheritdoc />
-        /// <remarks>Squadding Assignmetn is not a part of the REST API response for GetResultList. It is included here to allow the Result
-        /// List Formatter access to squadding information, so it may display it on a formatted result list.</remarks>
-        [G_NS.JsonIgnore]
-        [G_STJ_SER.JsonIgnore]
-        public SquaddingAssignment SquaddingAssignment { get; set; }
-
-
-        /// <inheritdoc />
-		public List<IEventScoreProjection> GetTeamMembersAsIEventScoreProjection() {
-            if (TeamMembers == null) {
-                return new List<IEventScoreProjection>();
-            }
-
-            return TeamMembers.ToList<IEventScoreProjection>();
-        }
-
-        /// <inheritdoc />
-        public void SetTeamMembersFromIEventScoreProjection( List<IEventScoreProjection> teamMembers ) {
-
-            if (TeamMembers == null)
-                TeamMembers = new List<ResultEvent>();
-
-            TeamMembers.Clear();
-
-            foreach (var tm in teamMembers) {
-                TeamMembers.Add( (ResultEvent)tm );
-            }
-        }
-
-        /// <inheritdoc />
-        public void ProjectScores( ProjectorOfScores ps ) {
-            ps.ProjectEventScores( this );
-        }
-
         [G_STJ_SER.JsonPropertyOrder( 11 )]
         [G_NS.JsonProperty( Order = 11 )]
         public Dictionary<string, EventScore> EventScores { get; set; }
@@ -143,32 +116,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_STJ_SER.JsonPropertyOrder( 12 )]
         [G_NS.JsonProperty( Order = 12 )]
         public Dictionary<string, EventScore> ResultCofScores { get; set; }
-
-        public bool ShouldSerializeResultCOFScores() {
-            return (ResultCofScores != null && ResultCofScores.Count > 0);
-        }
-
-        /// <summary>
-        /// The idea of this name scheme for the key is to use matchId as a namespace. Since each event name within a
-        /// match has to be unique, and each matchId is unique, then the key too will be unique.
-        /// </summary>
-        /// <param name="matchId"></param>
-        /// <param name="eventName"></param>
-        /// <returns></returns>
-        public static string KeyForResultCofScore( string matchId, string eventName ) {
-            return $"{matchId}: {eventName}";
-        }
-
-        /// <summary>
-        /// The idea of this name scheme for the key is to use matchId as a namespace. Since each event name within a
-        /// match has to be unique, and each matchId is unique, then the key too will be unique.
-        /// </summary>
-        /// <param name="matchId"></param>
-        /// <param name="eventName"></param>
-        /// <returns></returns>
-        public static string KeyForResultCofScore( MatchID matchId, string eventName ) {
-            return $"{matchId}: {eventName}";
-        }
 
         /// <summary>
         /// Scores for each Singular Event (usually a Shot).
@@ -196,8 +143,106 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         //returned json (as would be the case for Orion 2.23 or before)
         public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 
-        //Cached copy of the name of the top level event.
-        private string _topLevelEventName = "";
+        /// <summary>
+        /// If this is a team score, the TeamMembers will be the scores of the team members. If this is an Individual value will be null.
+        /// </summary>
+        [G_STJ_SER.JsonPropertyOrder( 21 )]
+        [G_NS.JsonProperty( Order = 21 )]
+        public List<ResultEvent>? TeamMembers { get; set; }
+
+
+        /// <summary>
+        /// The list of <see cref="RemarkAction"/> this Participant has for this Course of Fire. This can include things like DNS, DSQ, or in a Final AT RISK.
+        /// </summary>
+        /// <remarks>The value of the RemarkList is copied from the <see cref="CourseOfFireEntry.RemarkList"/>.</remarks>
+        [G_STJ_SER.JsonPropertyOrder( 25 )]
+        [G_NS.JsonProperty( Order = 25 )]
+        public RemarkList RemarkList { get; set; } = new RemarkList();
+
+        #endregion
+
+        #region Helper Properties
+
+        /// <inheritdoc />
+        /// <remarks>Squadding Assignmetn is not a part of the REST API response for GetResultList. It is included here to allow the Result
+        /// List Formatter access to squadding information, so it may display it on a formatted result list.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public SquaddingAssignment SquaddingAssignment { get; set; }
+
+        /// <summary>
+        /// Helper property to easily check if this participant is shooting out of competition (for score only). This is determined by checking if the RemarkList contains a ParticipantRemark of OUT_OF_COMPETITION.
+        /// </summary>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public bool OutOfCompetition {
+            get {
+                return RemarkList.IsShowingParticipantRemark( ParticipantRemark.OUT_OF_COMPETITION );
+            }
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; } = string.Empty;
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc />
+        public List<IEventScoreProjection> GetTeamMembersAsIEventScoreProjection() {
+            if (TeamMembers == null) {
+                return new List<IEventScoreProjection>();
+            }
+
+            return TeamMembers.ToList<IEventScoreProjection>();
+        }
+
+        /// <inheritdoc />
+        public void SetTeamMembersFromIEventScoreProjection( List<IEventScoreProjection> teamMembers ) {
+
+            if (TeamMembers == null)
+                TeamMembers = new List<ResultEvent>();
+
+            TeamMembers.Clear();
+
+            foreach (var tm in teamMembers) {
+                TeamMembers.Add( (ResultEvent)tm );
+            }
+        }
+
+        /// <inheritdoc />
+        public void ProjectScores( ProjectorOfScores ps ) {
+            ps.ProjectEventScores( this );
+        }
+
+        public bool ShouldSerializeResultCOFScores() {
+            return (ResultCofScores != null && ResultCofScores.Count > 0);
+        }
+
+        /// <summary>
+        /// The idea of this name scheme for the key is to use matchId as a namespace. Since each event name within a
+        /// match has to be unique, and each matchId is unique, then the key too will be unique.
+        /// </summary>
+        /// <param name="matchId"></param>
+        /// <param name="eventName"></param>
+        /// <returns></returns>
+        public static string KeyForResultCofScore( string matchId, string eventName ) {
+            return $"{matchId}: {eventName}";
+        }
+
+        /// <summary>
+        /// The idea of this name scheme for the key is to use matchId as a namespace. Since each event name within a
+        /// match has to be unique, and each matchId is unique, then the key too will be unique.
+        /// </summary>
+        /// <param name="matchId"></param>
+        /// <param name="eventName"></param>
+        /// <returns></returns>
+        public static string KeyForResultCofScore( MatchID matchId, string eventName ) {
+            return $"{matchId}: {eventName}";
+        }
 
         /// <inheritdoc />
 		public ResultStatus GetStatus() {
@@ -221,13 +266,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         }
 
         /// <summary>
-        /// If this is a team score, the TeamMembers will be the scores of the team members. If this is an Individual value will be null.
-        /// </summary>
-        [G_STJ_SER.JsonPropertyOrder( 21 )]
-        [G_NS.JsonProperty( Order = 21 )]
-        public List<ResultEvent>? TeamMembers { get; set; }
-
-        /// <summary>
         /// A Newtonsoft Conditional Property to only serialize TeamMembers when the list has something in it.
         /// https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
         /// </summary>
@@ -235,20 +273,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public bool ShouldSerializeTeamMembers() {
             return (TeamMembers != null && TeamMembers.Count > 0);
         }
-
-
-        /// <summary>
-        /// The list of <see cref="RemarkAction"/> this Participant has for this Course of Fire. This can include things like DNS, DSQ, or in a Final AT RISK.
-        /// </summary>
-        /// <remarks>The value of the RemarkList is copied from the <see cref="CourseOfFireEntry.RemarkList"/>.</remarks>
-        [G_STJ_SER.JsonPropertyOrder( 25 )]
-        [G_NS.JsonProperty( Order = 25 )]
-        public RemarkList RemarkList { get; set; } = new RemarkList();
-
-        /// <inheritdoc/>
-        [G_STJ_SER.JsonPropertyOrder( 26 )]
-        [G_NS.JsonProperty( Order = 26 )]
-        public bool OutOfCompetition { get; set; }
 
         /// <summary>
         /// Newtonsoft Conditional Property to only serialize RemarkList when the list has something in it.
@@ -260,16 +284,16 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         /// <inheritdoc />
         public Dictionary<string, Athena.Shot.Shot> GetShotsByEventName() {
-            if (shotsByEventName != null)
-                return shotsByEventName;
+            if (_shotsByEventName != null)
+                return _shotsByEventName;
 
-            shotsByEventName = new Dictionary<string, Athena.Shot.Shot>();
+            _shotsByEventName = new Dictionary<string, Athena.Shot.Shot>();
 
             foreach (var t in Shots.Values)
                 if (!string.IsNullOrEmpty( t.EventName ))
-                    shotsByEventName.Add( t.EventName, t );
+                    _shotsByEventName.Add( t.EventName, t );
 
-            return shotsByEventName;
+            return _shotsByEventName;
         }
 
         /// <inheritdoc />
@@ -285,12 +309,6 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             }
             return lastShot;
         }
-
-        /// <inheritdoc />
-        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
-        [G_NS.JsonIgnore]
-        [G_STJ_SER.JsonIgnore]
-        public string CheckSum { get; set; } = string.Empty;
 
         /// <inheritdoc />
         public bool CurrentlyCompetingOrRecentlyDone() {
@@ -338,5 +356,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
             return hash;
         }
+
+        #endregion
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/ResultEvent.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultEvent.cs
@@ -352,7 +352,11 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
                 }
             }
 
-            // NOTE: We are purposefully not including Shots in the checksum calculation, as this property is not included in the REST API response for ResultEvents.
+            if (LastShot is not null) {
+                hash ^= LastShot.CalculateChecksum();
+            }
+
+            // NOTE: We are purposefully not including the Shots property in the checksum calculation, as this property is not included in the REST API response for ResultEvents.
 
             return hash;
         }

--- a/src/BabelFish/DataModel/OrionMatch/ResultList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultList.cs
@@ -520,7 +520,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// </summary>
         /// <returns>A ulong containing the calculated checksum value for the object.</returns>
         public ulong CalculateChecksum() {
-            string combined = $"{MatchName}|{ResultName}|{EventName}|{ParentID}|{StartDate.ToString( DateTimeFormats.DATE_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATE_FORMAT )}|{Team}|{Projected}|{RankingRuleDef}|{CourseOfFireDef}|{ResultListFormatDef}";
+            string combined = $"{MatchName}|{ResultName}|{EventName}|{ParentID}|{Status}|{StartDate.ToString( DateTimeFormats.DATE_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATE_FORMAT )}|{Team}|{Projected}|{RankingRuleDef}|{CourseOfFireDef}|{ResultListFormatDef}";
             var hash = Helpers.Common.Md5ToUlong( combined );
 
             // We are safe to not care about the order of the items, since if any item is re-arranged, the SortOrder property (within the item) is updated and thus their CalculateCheckSum will change.

--- a/src/BabelFish/DataModel/OrionMatch/ResultList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultList.cs
@@ -18,7 +18,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         IGetCourseOfFireDefinition,
         IGetRankingRuleDefinition,
         IPublishTransactions,
-        ISaveToFile {
+        ISaveToFile,
+        ICheckSum {
 
         #region Private Variables
         private ResultStatus _localStatus = ResultStatus.UNOFFICIAL;
@@ -310,6 +311,9 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         [G_NS.JsonProperty( Order = 30 )]
         public List<ResultEvent> Items { get; set; } = new List<ResultEvent>();
 
+        [G_NS.JsonProperty( Order = 97 )]
+        public string CheckSum { get; set; } = string.Empty;
+
         /// <summary>
         /// When serialized, this is the BableFish version string that the data model of this ResultList instance adheres to.
         /// </summary>
@@ -375,6 +379,17 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             }
         }
 
+        /// <summary>
+        /// Readonly facade property that returns the same as .ResultName
+        /// </summary>
+        /// <remarks>Property is not serialized.</remarks>
+        [G_NS.JsonIgnore]
+        public string Name {
+            get {
+                return this.ResultName;
+            }
+        }
+
         #endregion
 
         #region Deprecated Data Model Properties
@@ -408,6 +423,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public string ResultListID { get; set; } = string.Empty;
 
         #endregion
+
 
         #endregion
 
@@ -497,14 +513,21 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         }
 
         /// <summary>
-        /// Readonly facade property that returns the same as .ResultName
+        /// Calculates a checksum value that represents the current state of the object's properties, excluding the
+        /// LastUpdated and CheckSum properties.
+        /// <para>After an object is deserialized, this method can be used to verify the integrity of the deserialized data by comparing
+        /// the calculated value against the stored CheckSum.</para>
         /// </summary>
-        /// <remarks>Property is not serialized.</remarks>
-        [G_NS.JsonIgnore]
-        public string Name {
-            get {
-                return this.ResultName;
+        /// <returns>A ulong containing the calculated checksum value for the object.</returns>
+        public ulong CalculateChecksum() {
+            string combined = $"{MatchName}|{ResultName}|{EventName}|{ParentID}|{StartDate.ToString( DateTimeFormats.DATE_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATE_FORMAT )}|{Team}|{Projected}|{RankingRuleDef}|{CourseOfFireDef}|{ResultListFormatDef}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            // We are safe to not care about the order of the items, since if any item is re-arranged, the SortOrder property (within the item) is updated and thus their CalculateCheckSum will change.
+            foreach (var item in this.Items) {
+                hash ^= item.CalculateChecksum();
             }
+            return hash;
         }
 
         /// <inheritdoc />

--- a/src/BabelFish/DataModel/OrionMatch/ResultList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultList.cs
@@ -295,7 +295,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// the Precision Air Rifle marksmen).</para>
         /// </summary>
         [G_NS.JsonProperty( Order = 24 )]
-        public AttributeFilter AttributeFilter { get; set; } = AttributeFilter.DEFAULT;
+        public AttributeFilter AttributeFilter { get; set; } = new AttributeFilterNone();
 
         /// <inheritdoc />
         [G_NS.JsonProperty( Order = 25 )]

--- a/src/BabelFish/DataModel/OrionMatch/ResultListAbbr.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultListAbbr.cs
@@ -21,7 +21,8 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     public class ResultListAbbr :
         IEquatable<ResultListAbbr>,
         IEqualityComparer<ResultListAbbr>,
-        IFinishInitializationAsync {
+        IFinishInitializationAsync,
+        ICheckSum {
 
         #region Private and Protected Fields
         private bool _ignoreEvents = false;
@@ -126,7 +127,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// </summary>
         /// <remarks>To test if a Participant passes the AttributeFilter, use the static <see cref="AttributeFilterCalculator.Passes(AttributeFilter, MatchParticipant)"/> method.</remarks>
         [G_NS.JsonProperty( Order = 14 )]
-        public AttributeFilter AttributeFilter { get; set; } = AttributeFilter.DEFAULT;
+        public AttributeFilter AttributeFilter { get; set; } = new AttributeFilterNone();
 
         /// <summary>
         /// Newtonsoft.json helper method, to determine if AttributeFilters should be serialized.
@@ -156,6 +157,20 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             [UserDefinedFieldNames.USER_DEFINED_FIELD_3] = string.Empty,
         };
 
+        #endregion
+
+        #region Helper Properties
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as this is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+        #endregion
+
+        #region Methods 
+
         /// <summary>
         /// Newtonsoft.json helper method, to determine if UserDefinedText should be serialized.
         /// </summary>
@@ -168,9 +183,32 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
                 (UserDefinedText.TryGetValue( UserDefinedFieldNames.USER_DEFINED_FIELD_3, out string text3 ) && !string.IsNullOrEmpty( text3 )));
         }
 
-        #endregion
+        public ulong CalculateChecksum() {
+            StringBuilder combined = new StringBuilder( $"{ResultName}|{Primary}|{Team}|{ResultListFormatDef}|{RankingRuleDef}|{ScoreConfigName}" );
 
-        #region Methods 
+            if (UserDefinedText.TryGetValue( UserDefinedFieldNames.USER_DEFINED_FIELD_1, out string text1 ) && !string.IsNullOrEmpty( text1 )) {
+                combined.Append( $"|{text1}" );
+            } else {
+                combined.Append( $"|none" );
+            }
+
+            if (UserDefinedText.TryGetValue( UserDefinedFieldNames.USER_DEFINED_FIELD_2, out string text2 ) && !string.IsNullOrEmpty( text2 )) {
+                combined.Append( $"|{text2}" );
+            } else {
+                combined.Append( $"|none" );
+            }
+
+            if (UserDefinedText.TryGetValue( UserDefinedFieldNames.USER_DEFINED_FIELD_3, out string text3 ) && !string.IsNullOrEmpty( text3 )) {
+                combined.Append( $"|{text3}" );
+            } else {
+                combined.Append( $"|none" );
+            }
+
+            var hash = Helpers.Common.Md5ToUlong( combined.ToString() );
+
+            hash ^= AttributeFilter.CalculateChecksum();
+            return hash;
+        }
 
         /// <summary>
         /// Returns a hash code that unique defines the structure of the Result List.</summary>

--- a/src/BabelFish/DataModel/OrionMatch/ResultListMember.cs
+++ b/src/BabelFish/DataModel/OrionMatch/ResultListMember.cs
@@ -4,8 +4,10 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// ResultListMember describes one of the ResultLists to pull data from within a <see cref="MergedResultList"/>.
     /// <para>Result Lists are uniquely identified through a combination of the MatchId, CourseOfFireId, and Result List name.</para>
     /// </summary>
-    public class ResultListMember {
+    public class ResultListMember :
+        ICheckSum {
 
+        #region Data Model Properties
         /// <summary>
         /// The Unique Match ID that is a Member of the Merged Result List.
         /// </summary>
@@ -31,5 +33,28 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// </summary>
         [G_NS.JsonProperty( Order = 4 )]
         public string HeaderName { get; set; } = string.Empty;
+
+        #endregion
+
+        #region Helper Properties
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as this is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{MatchId}|{CourseOfFireId}|{ResultName}|{HeaderName}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+            return hash;
+        }
+
+        #endregion
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/Squadding.cs
+++ b/src/BabelFish/DataModel/OrionMatch/Squadding.cs
@@ -4,7 +4,9 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// REST API Response Object class representing a Participant and their squadding assignment in a Match's event.
     /// It is the Item in a SquaddingList.
     /// </summary>
-    public class Squadding : IRLIFItem {
+    public class Squadding :
+        IRLIFItem,
+        ICheckSum {
 
         /// <summary>
         /// Constructor
@@ -24,6 +26,20 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <inheritdoc />
         public override string ToString() {
             return $"Squadding for {Participant.DisplayName}: {SquaddingAssignment}";
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var hash = this.Participant.CalculateChecksum();
+            hash ^= this.SquaddingAssignment.CalculateChecksum();
+
+            return hash;
         }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/SquaddingAssignment.cs
+++ b/src/BabelFish/DataModel/OrionMatch/SquaddingAssignment.cs
@@ -5,7 +5,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// <summary>
     /// Abstract class representing the complete squadding assignment for one participant (athlete or team).
     /// </summary>
-    public abstract class SquaddingAssignment {
+    public abstract class SquaddingAssignment : ICheckSum {
 
         /*
          * A description of how to describe Inherited / Abstract classes in OpenAPI 3.0 is at https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
@@ -51,5 +51,15 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             return this.ToString( false );
         }
 
+        /// <inheritdoc />
+        /// <remarks>Choosing not to include CheckSum in the serialized value, as it is not a top level document.</remarks>
+        [G_NS.JsonIgnore]
+        [G_STJ_SER.JsonIgnore]
+        public string CheckSum { get; set; }
+
+        /// <inheritdoc />
+        public virtual ulong CalculateChecksum() {
+            return Helpers.Common.Md5ToUlong( this.ToString( true ) );
+        }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/SquaddingList.cs
+++ b/src/BabelFish/DataModel/OrionMatch/SquaddingList.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 using Scopos.BabelFish.Converters.Microsoft;
 using Scopos.BabelFish.DataModel.Common;
 using Scopos.BabelFish.DataModel.Definitions;
@@ -9,7 +8,11 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
     /// <summary>
     /// Response object for a request of Squadding Assignments for a specified match and squadding event name.
     /// </summary>
-    public class SquaddingList : ITokenItems<Squadding>, IRLIFList, IPublishTransactions {
+    public class SquaddingList :
+        ITokenItems<Squadding>,
+        IRLIFList,
+        IPublishTransactions,
+        ICheckSum {
 
         private Logger logger = LogManager.GetCurrentClassLogger();
 
@@ -80,9 +83,9 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         public string Creator { get; set; } = string.Empty;
 
         /// <summary>
-        /// Set name of the Result List Format definition to use when displaying this squadding list.
+        /// Set name of the <see cref="ResultListFormat">RESULT LIST FORMAT</see> definition to use when displaying this SquaddingList.
         /// </summary>
-        [JsonPropertyOrder( 10 )]
+        [G_NS.JsonProperty( Order = 10 )]
         public SetName ResultListFormatDef { get; set; } = new SetName();
 
         /// <summary>
@@ -98,7 +101,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         /// <inheritdoc />
         [DefaultValue( "" )]
-        [JsonConverter( typeof( NextTokenConverter ) )]
+        [G_STJ_SER.JsonConverter( typeof( NextTokenConverter ) )]
         [G_NS.JsonProperty( Order = 21 )]
         public string NextToken { get; set; } = string.Empty;
 
@@ -280,6 +283,21 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
 
         public override string ToString() {
             return $"SquaddingList with {Items.Count} items";
+        }
+
+        /// <inheritdoc />
+        public string CheckSum { get; set; }
+
+        /// <inheritdoc />
+        public ulong CalculateChecksum() {
+            var combined = $"{EventName}|{MatchName}|{OwnerId}|{StartDate.ToString( DateTimeFormats.DATE_FORMAT )}|{EndDate.ToString( DateTimeFormats.DATE_FORMAT )}|{MatchID}|{Creator}|{ResultListFormatDef}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            foreach (var item in this.Items) {
+                hash ^= item.CalculateChecksum();
+            }
+
+            return hash;
         }
     }
 }

--- a/src/BabelFish/DataModel/OrionMatch/Team.cs
+++ b/src/BabelFish/DataModel/OrionMatch/Team.cs
@@ -51,7 +51,7 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
         /// <summary>
         /// Gets called when a Participant is added to the TeamMembers list. The event handler is passed the Participant that was added to the TeamMembers list.
         /// </summary>
-        public EventHandler<EventArgs<Participant>> OnTeamMemberAdded;
+        public event EventHandler<EventArgs<Participant>> OnTeamMemberAdded;
         #endregion
 
         #region Data Model Properties
@@ -92,6 +92,25 @@ namespace Scopos.BabelFish.DataModel.OrionMatch {
             get {
                 return this.DisplayName.GetHashCode();
             }
+        }
+
+
+        /// <inheritdoc />
+        public override ulong CalculateChecksum() {
+            var combined = $"{DisplayName}|{CompetitorNumber}|{Country}|{HomeTown}|{Club}|{TeamName}";
+            var hash = Helpers.Common.Md5ToUlong( combined );
+
+            foreach (var attributeValue in AttributeValues) {
+                hash ^= attributeValue.CalculateChecksum();
+            }
+
+            foreach (var teamCaptain in TeamCaptains) {
+                hash ^= teamCaptain.CalculateChecksum();
+            }
+
+            hash ^= RemarkList.CalculateChecksum();
+
+            return hash;
         }
     }
 }

--- a/src/BabelFish/Helpers/Common.cs
+++ b/src/BabelFish/Helpers/Common.cs
@@ -851,7 +851,19 @@ namespace Scopos.BabelFish.Helpers {
             return new string( result );
         }
 
+        /// <summary>
+        /// Uses MD5 to hash the input string and then converts the first 8 bytes of the hash to a ulong. This can be used to create a unique
+        /// identifier for a string, such as a username or email address, without storing the original string in plaintext.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static ulong Md5ToUlong( string input ) {
+            MD5 mD5 = MD5.Create();
+            byte[] bytes = Encoding.UTF8.GetBytes( input );
+            byte[] hash = mD5.ComputeHash( bytes );
 
-
+            // Take the first 8 bytes and convert to ulong
+            return BitConverter.ToUInt64( hash, 0 );
+        }
     }
 }

--- a/tests/BabelFish.Tests/APIClients/OrionMatchAPIClientTests/CheckSumTests.cs
+++ b/tests/BabelFish.Tests/APIClients/OrionMatchAPIClientTests/CheckSumTests.cs
@@ -1,0 +1,139 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Scopos.BabelFish.APIClients;
+using Scopos.BabelFish.DataModel.Athena;
+using Scopos.BabelFish.DataModel.Athena.Shot;
+using Scopos.BabelFish.DataModel.AttributeValue;
+using Scopos.BabelFish.DataModel.Definitions;
+using Scopos.BabelFish.DataModel.OrionMatch;
+using Score = Scopos.BabelFish.DataModel.Athena.Score;
+
+namespace BabelFish.Tests.OrionMatch {
+
+    [TestClass]
+    public class CheckSumTests : BaseTestClass {
+
+        [TestMethod]
+        public void ShotCheckSumTest() {
+            var shot1 = new Shot() {
+                EventName = "S2",
+                BulletDiameter = 4.5f,
+                ScoringDiameter = 4.5f,
+                Location = new Location() { X = 10, Y = 20 },
+                Score = new Score() { I = 10, D = 10.4f, X = 1 },
+                TargetSetName = "v1.0:issf:50m Rifle",
+                FiringPoint = "Firing Point 1",
+                Attributes = new List<string>() { "SIGHTER" },
+                StageLabel = "Stage 1",
+                Sequence = 1,
+                TargetName = "Target 1",
+                ResultCOFID = Guid.NewGuid().ToString(),
+                MatchID = MatchID.Parse( "1.1.123456.1" )
+            };
+            var shot2 = shot1.Clone();
+
+            //Without changing any properties, the checksums should be the same
+            Assert.AreEqual( shot1.CalculateChecksum(), shot2.CalculateChecksum(), "Identical shots should have the same checksum." );
+            Console.WriteLine( shot1.CalculateChecksum() );
+            Console.WriteLine( shot2.CalculateChecksum() );
+
+            shot2.EventName = "S3";
+            Assert.AreNotEqual( shot1.CalculateChecksum(), shot2.CalculateChecksum(), "Shots with different EventNames should have different checksums." );
+            Console.WriteLine( shot2.CalculateChecksum() );
+
+            var shot3 = shot1.Clone();
+            shot3.Score.I = 9;
+            Assert.AreNotEqual( shot1.CalculateChecksum(), shot3.CalculateChecksum(), "Shots with different Scores should have different checksums." );
+            Console.WriteLine( shot3.CalculateChecksum() );
+
+            var shot4 = shot1.Clone();
+            shot4.Location.X = 15;
+            Assert.AreNotEqual( shot1.CalculateChecksum(), shot4.CalculateChecksum(), "Shots with different Locations should have different checksums." );
+            Console.WriteLine( shot4.CalculateChecksum() );
+
+            var shot5 = shot1.Clone();
+            shot5.Attributes.Clear();
+            Assert.AreNotEqual( shot1.CalculateChecksum(), shot5.CalculateChecksum(), "Shots with different Attributes should have different checksums." );
+            Console.WriteLine( shot5.CalculateChecksum() );
+
+            var shot6 = shot1.Clone();
+            shot6.AddPenalty( new Penalty() { RuleNumber = "1.2.3", PenaltyPoints = 2 } );
+            Assert.AreNotEqual( shot1.CalculateChecksum(), shot6.CalculateChecksum(), "Shots with different Penalties should have different checksums." );
+            Console.Write( shot6.CalculateChecksum() );
+        }
+
+        [TestMethod]
+        public async Task IndividualCheckSumTest() {
+            var individual1 = new Individual() {
+                CompetitorNumber = "123",
+                GivenName = "John",
+                MiddleName = "A",
+                FamilyName = "Doe",
+                DisplayName = "John A Doe",
+                UserID = "user123",
+                Club = "Shooting Club",
+                Country = "USA",
+                HomeTown = "Minden, NE"
+            };
+
+            var individual2 = individual1.Clone();
+            Assert.AreEqual( individual1.CalculateChecksum(), individual2.CalculateChecksum(), "Identical individuals should have the same checksum." );
+            Console.WriteLine( individual1.CalculateChecksum() );
+            Console.WriteLine( individual2.CalculateChecksum() );
+
+            individual2.GivenName = "Jane";
+            Assert.AreNotEqual( individual1.CalculateChecksum(), individual2.CalculateChecksum(), "Individuals with different FirstNames should have different checksums." );
+            Console.WriteLine( individual2.CalculateChecksum() );
+
+            // Due to their nature, AttributeValues do not clone with the method Clone().
+            // So we need to create a new AttributeValue and add it to the individual to test that changing an AttributeValue changes the checksum.
+            var airRifleTypeSetName = SetName.Parse( "v1.0:ntparc:Three-Position Air Rifle Type" );
+            var threePositionAirRifleAttr = await DefinitionCache.GetAttributeDefinitionAsync( airRifleTypeSetName );
+            var av = await AttributeValue.CreateAsync( airRifleTypeSetName );
+
+            var individual3 = individual1.Clone();
+            individual3.AttributeValues.Add( new AttributeValueDataPacketMatch() {
+                AttributeDef = airRifleTypeSetName,
+                Visibility = Scopos.BabelFish.DataModel.Common.VisibilityOption.PUBLIC,
+                AttributeValue = av
+            } );
+            Assert.AreNotEqual( individual1.CalculateChecksum(), individual3.CalculateChecksum(), "Individuals with different AttributeValues should have different checksums." );
+            Console.WriteLine( individual3.CalculateChecksum() );
+        }
+
+        [TestMethod]
+        public async Task ResultListCheckSumTests() {
+            var client = new OrionMatchAPIClient();
+            var resultListResponse = await client.GetResultListAsync( MatchID.Parse( "1.2413.2026050816212089.0" ), "Individual - Sporter" );
+            var resultList = resultListResponse.ResultList;
+
+            // Each ResultEvent in .Items should have a different CheckSum.
+            HashSet<ulong> checksums = new HashSet<ulong>();
+            foreach (var resultEvent in resultList.Items) {
+                var checksum = resultEvent.CalculateChecksum();
+                if (checksums.Contains( checksum )) {
+                    Assert.Fail( $"Duplicate checksum found for ResultEvent with CompetitorNumber {resultEvent.Participant.CompetitorNumber}." );
+                }
+                checksums.Add( checksum );
+            }
+
+            var stopWatch = System.Diagnostics.Stopwatch.StartNew();
+            var currentCheckSumToCheckAgainst = resultList.CalculateChecksum();
+            stopWatch.Stop();
+            Console.WriteLine( currentCheckSumToCheckAgainst );
+            Console.WriteLine( stopWatch.ElapsedMilliseconds );
+
+            // Changing the CompetitorNumber of the first ResultEvent should change the checksum of the entire ResultList.
+            resultList.Items[0].Participant.CompetitorNumber = "999";
+            Assert.AreNotEqual( currentCheckSumToCheckAgainst, resultList.CalculateChecksum(), "Changing a ResultEvent's CompetitorNumber should change the ResultList checksum." );
+            currentCheckSumToCheckAgainst = resultList.CalculateChecksum();
+            Console.WriteLine( currentCheckSumToCheckAgainst );
+
+            // Changing the Score of the first ResultEvent should change the checksum of the entire ResultList.
+            resultList.Items[0].EventScores.First().Value.Score.I = 5;
+            Assert.AreNotEqual( currentCheckSumToCheckAgainst, resultList.CalculateChecksum(), "Changing a ResultEvent's Score should change the ResultList checksum." );
+            currentCheckSumToCheckAgainst = resultList.CalculateChecksum();
+            Console.WriteLine( currentCheckSumToCheckAgainst );
+        }
+    }
+}

--- a/tests/BabelFish.Tests/Constants.cs
+++ b/tests/BabelFish.Tests/Constants.cs
@@ -47,9 +47,12 @@ namespace Scopos.BabelFish.Tests {
     }
 
     public class BasicUserCredentials {
-        public string Username { get; set;}
-        public string Password { get; set;}
-        public string DeviceKey { get;  set;}
-        public string DeviceGroupKey { get; set;}
+        /// <summary>
+        /// In this context, same as the user's email address.
+        /// </summary>
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public string DeviceKey { get; set; }
+        public string DeviceGroupKey { get; set; }
     }
 }


### PR DESCRIPTION
- Implemented the ICheckSum interface. Originally implemented in branch release_1.12.5 and merged in. Any new data structures in BabelFish 2.0 updated to implement as well.
- Moved Out of Competition to being a Remark.